### PR TITLE
Initialize default creep profiles

### DIFF
--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -3,7 +3,7 @@
 
 import { createDefaultMap, cellCenterForMap } from './map.js';
 import { makeRng } from './rng.js';
-import { Elt } from './content.js';
+import { Elt, ResistProfiles } from './content.js';
 
 export function createInitialState(seedState) {
     const rng = makeRng(seedState?.seed ?? undefined);
@@ -34,6 +34,9 @@ export function createInitialState(seedState) {
         bullets: [],
         events: [],
         particles: [],
+
+        // Default creep profiles. Allows override via seedState.creepProfiles
+        creepProfiles: seedState?.creepProfiles ?? structuredClone(ResistProfiles),
 
         selectedTowerId: null,
         hover: { gx: -1, gy: -1, valid: false },


### PR DESCRIPTION
## Summary
- Ensure initial game state includes creep profiles by default, preventing spawn errors

## Testing
- ⚠️ `npm test` *(no test script)*
- ✅ `node -e "import('./packages/core/engine.js').then(m=>{const e=m.createEngine(); console.log('creepProfiles keys:', Object.keys(e.state.creepProfiles));});"`

------
https://chatgpt.com/codex/tasks/task_e_68a7d55aa0ac8330bb9b18738e643cff