### PR TITLE
refactor: remove leftover emitter.emit usage

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -1,7 +1,7 @@
 // packages/core/bullets.js
 import { takeDamage, applyStatus } from './combat.js';
 
-export function updateBullets(state, emitter) {
+export function updateBullets(state, { onCreepDamage }) {
     for (let i = state.bullets.length - 1; i >= 0; i--) {
         const b = state.bullets[i];
         b.ttl -= state.dt;
@@ -18,10 +18,10 @@ export function updateBullets(state, emitter) {
                         takeDamage(c, b.dmg, b.elt, c.status.resShred || 0);
                         applyStatus(c, b.status, fromT);
                         hitAny = true;
+                        onCreepDamage?.({ creep: c, amount: b.dmg, elt: b.elt, towerId: fromT?.id });
                     }
                 }
                 if (hitAny) state.hits++;
-                emitter.emit({ type: 'fx.aoe', x: b.x, y: b.y, r: b.aoe, color: b.color, ttl: 0.18 });
             }
             state.bullets.splice(i, 1);
         }

--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -36,15 +36,14 @@ export function advanceCreep(state, c, onLeak) {
   if (c.t >= d) { c.seg++; c.t = 0; c.x = c.path[c.seg].x; c.y = c.path[c.seg].y; }
 }
 
-export function cullDead(state, emitter, onKill) {
+export function cullDead(state, { onKill }) {
   for (let i = state.creeps.length - 1; i >= 0; i--) {
     const c = state.creeps[i];
     if (!c.alive || c.hp <= 0) {
       if (c.hp <= 0) {
         state.gold += c.gold;
         state.score += 3;
-        onKill(c);
-        emitter.emit({ type: 'creep.kill', creep: { id: c.id, type: c.type } });
+        onKill?.(c);
       }
       state.creeps.splice(i, 1);
     }


### PR DESCRIPTION
## Summary
- remove lingering `emitter.emit` calls and switch to explicit callbacks
- forward damage events from bullets and towers
- streamline creep culling to rely on provided `onKill` handler

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7df8b75b08330b1a3dc55151f9393