### PR TITLE
Fix creep pathing to respect walls

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -8,10 +8,11 @@ import { tickStatusesAndCombos } from './combat.js';
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
   const p = astar(start, end, isBlocked, size.cols, size.rows);
-  state.path = (p || [start, end]).map(n => cellCenterForMap(state.map, n.x, n.y));
+  state.path = p ? p.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
   for (const c of state.creeps) {
     const startCell = toCell(state, c.x, c.y);
-    const npcPath = astar({ x: startCell.gx, y: startCell.gy }, end, isBlocked, size.cols, size.rows);
+    const blocker = (gx, gy) => (gx === startCell.gx && gy === startCell.gy) ? false : isBlocked(gx, gy);
+    const npcPath = astar({ x: startCell.gx, y: startCell.gy }, end, blocker, size.cols, size.rows);
     if (npcPath) { c.path = npcPath.map(n => cellCenterForMap(state.map, n.x, n.y)); c.seg = 0; c.t = 0; }
   }
 }

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -280,8 +280,8 @@ export function createEngine(seedState) {
             gold: base.gold,
             status: {},
             alive: true,
-            path: (state.pathPx && state.pathPx.length >= 2)
-                ? [...state.pathPx]
+            path: (state.path && state.path.length >= 2)
+                ? [...state.path]
                 : [startPx, endPx]
         };
 


### PR DESCRIPTION
## Summary
- Recompute paths using actual map path and ignore blocking on a creep's current tile to reroute around new obstacles
- Spawn creeps using the map's computed path so they follow walls correctly

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7e1cf534c8330be0bb60657abdd7a