### PR TITLE
cache paths for placement checks

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -8,7 +8,8 @@ import { tickStatusesAndCombos } from './combat.js';
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
   const p = astar(start, end, isBlocked, size.cols, size.rows);
-  state.path = (p || [start, end]).map(n => cellCenterForMap(state.map, n.x, n.y));
+  state.path = p || [start, end];
+  state.pathPx = state.path.map(n => cellCenterForMap(state.map, n.x, n.y));
   for (const c of state.creeps) {
     const startCell = toCell(state, c.x, c.y);
     const npcPath = astar({ x: startCell.gx, y: startCell.gy }, end, isBlocked, size.cols, size.rows);

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -50,11 +50,20 @@ export function createEngine(seedState) {
         if (gx === end.x && gy === end.y) return false;
         if (!canBuildCell(gx, gy)) return false;
         if (state.towers.some(t => t.gx === gx && t.gy === gy)) return false;
-        // simulate and ensure path exists
-        state.towers.push({ gx, gy, ghost: true });
-        const p = astar(state.map.start, state.map.end, isBlocked, state.map.size.cols, state.map.size.rows);
-        state.towers.pop();
-        return !!p;
+        const cached = state.path;
+        const onPath = cached?.some(n => n.x === gx && n.y === gy);
+        if (!cached || !cached.length || onPath) {
+            const p = astar(
+                state.map.start,
+                state.map.end,
+                (x, y) => (x === gx && y === gy) || isBlocked(x, y),
+                state.map.size.cols,
+                state.map.size.rows,
+            );
+            return !!p;
+        }
+        // tile not on cached path; existing path remains valid
+        return true;
     }
 
     function placeTower(gx, gy, elt) {

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -41,6 +41,7 @@ export function createInitialState(seedState) {
         hover: { gx: -1, gy: -1, valid: false },
 
         path: [],
+        pathPx: [],
 
         gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
@@ -66,7 +67,7 @@ export function resetState(state, keep = {}) {
 
         towers: [], creeps: [], bullets: [], events: [], particles: [],
         selectedTowerId: null, hover: { gx: -1, gy: -1, valid: false },
-        path: [], gameOver: false,
+        path: [], pathPx: [], gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
     });
 


### PR DESCRIPTION
## Summary
- Track both grid and pixel paths in state and recompute creep paths accordingly
- Speed up tower placement validation by only re-running A* when the tile lies on the cached path

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7e213c3788330b9cf744f4ab38186