### PR TITLE
feat: add elemental bullet effects

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -1,6 +1,33 @@
 // packages/core/bullets.js
 import { takeDamage, applyStatus } from './combat.js';
 
+function spawnImpact(state, b) {
+    const rng = state.rng;
+    const color = b.color || '#94a3b8';
+    let count = 6, speed = 40, ttl = 0.4, ring = 12;
+    switch (b.elt) {
+        case 'FIRE':
+            count = 8; speed = 90; ttl = 0.4; ring = 18; break;
+        case 'ICE':
+            count = 6; speed = 50; ttl = 0.6; ring = 14; break;
+        case 'LIGHT':
+            count = 10; speed = 130; ttl = 0.3; ring = 20; break;
+        case 'POISON':
+            count = 7; speed = 45; ttl = 0.6; ring = 16; break;
+    }
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
+    for (let n = 0; n < count; n++) {
+        const ang = rng() * Math.PI * 2;
+        const sp = speed * (0.5 + rng());
+        state.particles.push({
+            x: b.x, y: b.y,
+            vx: Math.cos(ang) * sp,
+            vy: Math.sin(ang) * sp,
+            ttl, max: ttl, a: 1, color,
+        });
+    }
+}
+
 export function updateBullets(state, { onCreepDamage }) {
     for (let i = state.bullets.length - 1; i >= 0; i--) {
         const b = state.bullets[i];
@@ -23,6 +50,7 @@ export function updateBullets(state, { onCreepDamage }) {
                 }
                 if (hitAny) state.hits++;
             }
+            spawnImpact(state, b);
             state.bullets.splice(i, 1);
         }
     }

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -6,6 +6,7 @@ import { defaultWaveConfig, createWaveController } from './waves.js';
 import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
 import { fireTower } from './towers.js';
 import { updateBullets } from './bullets.js';
+import { updateParticles } from './particles.js';
 import { astar } from './pathfinding.js';
 import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
@@ -215,6 +216,7 @@ export function createEngine(seedState) {
         for (const t of state.towers) { if (!t.ghost) fireTower(state, { onShot, onHit, onCreepDamage }, t, dt); }
 
         updateBullets(state, { onCreepDamage });
+        updateParticles(state);
 
         cullDead(state, {
             onKill: (c) => { onCreepKill(c); onGoldChange(+c.gold, 'kill'); },

--- a/packages/core/particles.js
+++ b/packages/core/particles.js
@@ -1,0 +1,14 @@
+// packages/core/particles.js
+// Simple particle updater for bullet impact effects
+
+export function updateParticles(state) {
+    for (let i = state.particles.length - 1; i >= 0; i--) {
+        const p = state.particles[i];
+        p.ttl -= state.dt;
+        if (p.vx) p.x += p.vx * state.dt;
+        if (p.vy) p.y += p.vy * state.dt;
+        if (p.vr) p.r += p.vr * state.dt;
+        p.a = p.ttl / p.max;
+        if (p.ttl <= 0) state.particles.splice(i, 1);
+    }
+}

--- a/packages/core/towers.js
+++ b/packages/core/towers.js
@@ -55,6 +55,7 @@ function attemptBoltHit(state, { onHit, onCreepDamage }, t, target, dmg, acc) {
         ttl: dist / speed,
         color: EltColor[t.elt],
         fromId: t.id,
+        elt: t.elt,
     });
 
     const hit = state.rng() < acc; if (hit) { state.hits++; onHit?.(t.id); }
@@ -111,6 +112,7 @@ function chainStrategy(state, callbacks, t, target, dmg, acc) {
             vy: (dy / dist) * speed,
             ttl: dist / speed,
             color: EltColor[t.elt],
+            elt: t.elt,
         });
 
         takeDamage(next, dmg * 0.6, t.elt, next.status.resShred || 0);

--- a/packages/render-canvas/index.js
+++ b/packages/render-canvas/index.js
@@ -163,9 +163,38 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
   function drawBullets(state) {
     for (const b of state.bullets) {
       ctx.save();
+      ctx.translate(b.x, b.y);
       ctx.fillStyle = b.color || '#94a3b8';
       ctx.shadowColor = ctx.fillStyle; ctx.shadowBlur = 12;
-      ctx.beginPath(); ctx.arc(b.x, b.y, b.r || 4, 0, Math.PI * 2); ctx.fill();
+
+      switch (b.elt) {
+        case 'FIRE': {
+          ctx.beginPath(); ctx.arc(0, 0, b.r || 4, 0, Math.PI * 2); ctx.fill();
+          const ang = Math.atan2(b.vy, b.vx);
+          ctx.rotate(ang);
+          ctx.fillRect(-4, -1, -8, 2);
+          break;
+        }
+        case 'ICE': {
+          ctx.rotate(Math.PI / 4);
+          ctx.fillRect(-3, -3, 6, 6);
+          break;
+        }
+        case 'LIGHT': {
+          ctx.beginPath();
+          ctx.moveTo(-4, 0); ctx.lineTo(0, -4); ctx.lineTo(4, 0); ctx.lineTo(0, 4);
+          ctx.closePath(); ctx.fill();
+          break;
+        }
+        case 'POISON': {
+          ctx.beginPath(); ctx.arc(0, 0, b.r || 4, 0, Math.PI * 2); ctx.fill();
+          ctx.globalAlpha = 0.3; ctx.fillRect(-4, -4, 8, 8); ctx.globalAlpha = 1;
+          break;
+        }
+        default: {
+          ctx.beginPath(); ctx.arc(0, 0, b.r || 4, 0, Math.PI * 2); ctx.fill();
+        }
+      }
       ctx.restore();
     }
   }


### PR DESCRIPTION
## Summary
- add `elt` to bullets and render different visuals per element
- create particle updater and integrate into engine
- spawn particle bursts on bullet impact for flashy effects

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7e898e2288330af3bf102fd51d224