### PR TITLE
refactor: centralize element effects

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -1,63 +1,12 @@
 // packages/core/bullets.js
 import { takeDamage, applyStatus } from './combat.js';
-
-function spawnImpact(state, b) {
-    const rng = state.rng;
-    const color = b.color || '#94a3b8';
-    let count = 6, speed = 40, ttl = 0.4, ring = 12;
-    switch (b.elt) {
-        case 'FIRE': {
-            count = 12; speed = 140; ttl = 0.5; ring = 22;
-            // bright flash for fiery explosion
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
-            break;
-        }
-        case 'ICE': {
-            count = 8; speed = 40; ttl = 0.7; ring = 16;
-            // icy spikes
-            for (let n = 0; n < 4; n++) {
-                const ang = rng() * Math.PI * 2;
-                state.particles.push({ x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
-                state.particles.push({ x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
-            }
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
-            break;
-        }
-        case 'LIGHT': {
-            count = 12; speed = 180; ttl = 0.3; ring = 20;
-            // electric sparks
-            for (let n = 0; n < 6; n++) {
-                const ang = rng() * Math.PI * 2;
-                const sp = 160;
-                state.particles.push({
-                    x: b.x, y: b.y,
-                    vx: Math.cos(ang) * sp,
-                    vy: Math.sin(ang) * sp,
-                    ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#faf5ff', spark: true,
-                });
-            }
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
-            break;
-        }
-        case 'POISON':
-            count = 7; speed = 45; ttl = 0.6; ring = 16; break;
-    }
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
-    for (let n = 0; n < count; n++) {
-        const ang = rng() * Math.PI * 2;
-        const sp = speed * (0.5 + rng());
-        state.particles.push({
-            x: b.x, y: b.y,
-            vx: Math.cos(ang) * sp,
-            vy: Math.sin(ang) * sp,
-            ttl, max: ttl, a: 1, color,
-        });
-    }
-}
+import { getEffect } from './effects/index.js';
 
 export function updateBullets(state, { onCreepDamage }) {
     for (let i = state.bullets.length - 1; i >= 0; i--) {
         const b = state.bullets[i];
+        const effect = getEffect(b.elt);
+        effect.trail(state, b);
         b.ttl -= state.dt;
         b.x += b.vx * state.dt;
         b.y += b.vy * state.dt;
@@ -76,8 +25,9 @@ export function updateBullets(state, { onCreepDamage }) {
                     }
                 }
                 if (hitAny) state.hits++;
+                effect.aoe(state, b);
             }
-            spawnImpact(state, b);
+            effect.impact(state, b);
             state.bullets.splice(i, 1);
         }
     }

--- a/packages/core/effects/default.js
+++ b/packages/core/effects/default.js
@@ -1,0 +1,32 @@
+// packages/core/effects/default.js
+// Generic effect descriptors for bullet behavior
+
+function trail(state, b) {
+    // default bullets have no trail effect
+}
+
+function basicImpact(state, b, opts = {}) {
+    const rng = state.rng;
+    const { count = 6, speed = 40, ttl = 0.4, ring = 12, color = b.color || '#94a3b8' } = opts;
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
+    for (let n = 0; n < count; n++) {
+        const ang = rng() * Math.PI * 2;
+        const sp = speed * (0.5 + rng());
+        state.particles.push({
+            x: b.x, y: b.y,
+            vx: Math.cos(ang) * sp,
+            vy: Math.sin(ang) * sp,
+            ttl, max: ttl, a: 1, color,
+        });
+    }
+}
+
+function impact(state, b) {
+    basicImpact(state, b);
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe, basicImpact };

--- a/packages/core/effects/earth.js
+++ b/packages/core/effects/earth.js
@@ -1,0 +1,17 @@
+// packages/core/effects/earth.js
+import base from './default.js';
+
+function trail(state, b) {
+    // subtle dust trail
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#d4d4d4', circle: true });
+}
+
+function impact(state, b) {
+    base.basicImpact(state, b, { color: b.color || '#a3a3a3' });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };

--- a/packages/core/effects/fire.js
+++ b/packages/core/effects/fire.js
@@ -1,0 +1,20 @@
+// packages/core/effects/fire.js
+import base from './default.js';
+
+function trail(state, b) {
+    // fiery embers trailing behind
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#fb923c', circle: true });
+}
+
+function impact(state, b) {
+    const rng = state.rng;
+    base.basicImpact(state, b, { count: 12, speed: 140, ttl: 0.5, ring: 22, color: b.color || '#f97316' });
+    // bright flash for fiery explosion
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };

--- a/packages/core/effects/ice.js
+++ b/packages/core/effects/ice.js
@@ -1,0 +1,25 @@
+// packages/core/effects/ice.js
+import base from './default.js';
+
+function trail(state, b) {
+    // cold mist trail
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+}
+
+function impact(state, b) {
+    const rng = state.rng;
+    base.basicImpact(state, b, { count: 8, speed: 40, ttl: 0.7, ring: 16, color: b.color || '#38bdf8' });
+    // icy spikes
+    for (let n = 0; n < 4; n++) {
+        const ang = rng() * Math.PI * 2;
+        state.particles.push({ x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+        state.particles.push({ x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+    }
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };

--- a/packages/core/effects/index.js
+++ b/packages/core/effects/index.js
@@ -1,0 +1,23 @@
+// packages/core/effects/index.js
+import def from './default.js';
+import fire from './fire.js';
+import ice from './ice.js';
+import light from './light.js';
+import poison from './poison.js';
+import earth from './earth.js';
+import wind from './wind.js';
+
+const registry = {
+    FIRE: fire,
+    ICE: ice,
+    LIGHT: light,
+    POISON: poison,
+    EARTH: earth,
+    WIND: wind,
+};
+
+export function getEffect(elt) {
+    return registry[elt] || def;
+}
+
+export { registry };

--- a/packages/core/effects/light.js
+++ b/packages/core/effects/light.js
@@ -1,0 +1,33 @@
+// packages/core/effects/light.js
+import base from './default.js';
+
+function trail(state, b) {
+    const rng = state.rng;
+    if (rng() < 0.5) {
+        const ang = rng() * Math.PI * 2;
+        state.particles.push({ x: b.x, y: b.y, ang, len: 6, ttl: 0.2, max: 0.2, a: 1, color: '#faf5ff', spark: true });
+    }
+}
+
+function impact(state, b) {
+    const rng = state.rng;
+    base.basicImpact(state, b, { count: 12, speed: 180, ttl: 0.3, ring: 20, color: b.color || '#a78bfa' });
+    // electric sparks
+    for (let n = 0; n < 6; n++) {
+        const ang = rng() * Math.PI * 2;
+        const sp = 160;
+        state.particles.push({
+            x: b.x, y: b.y,
+            vx: Math.cos(ang) * sp,
+            vy: Math.sin(ang) * sp,
+            ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#faf5ff', spark: true,
+        });
+    }
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };

--- a/packages/core/effects/poison.js
+++ b/packages/core/effects/poison.js
@@ -1,0 +1,16 @@
+// packages/core/effects/poison.js
+import base from './default.js';
+
+function trail(state, b) {
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.25, max: 0.25, a: 1, color: '#4ade80', circle: true });
+}
+
+function impact(state, b) {
+    base.basicImpact(state, b, { count: 7, speed: 45, ttl: 0.6, ring: 16, color: b.color || '#22c55e' });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };

--- a/packages/core/effects/wind.js
+++ b/packages/core/effects/wind.js
@@ -1,0 +1,17 @@
+// packages/core/effects/wind.js
+import base from './default.js';
+
+function trail(state, b) {
+    // faint breeze trails
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#93c5fd', circle: true });
+}
+
+function impact(state, b) {
+    base.basicImpact(state, b, { color: b.color || '#60a5fa' });
+}
+
+function aoe(state, b) {
+    impact(state, b);
+}
+
+export default { trail, impact, aoe };


### PR DESCRIPTION
## Summary
- modularize bullet trail/impact/AoE logic by element
- replace switch-based bullet effects with registry lookups and default handler

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fe0128f083308152e70df942c544