### PR TITLE
feat: pool particles for bullet impacts

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -1,5 +1,12 @@
 // packages/core/bullets.js
 import { takeDamage, applyStatus } from './combat.js';
+import { acquireParticle } from './particles.js';
+
+function addParticle(state, props) {
+    const p = acquireParticle();
+    Object.assign(p, props);
+    state.particles.push(p);
+}
 
 function spawnImpact(state, b) {
     const rng = state.rng;
@@ -9,7 +16,7 @@ function spawnImpact(state, b) {
         case 'FIRE': {
             count = 12; speed = 140; ttl = 0.5; ring = 22;
             // bright flash for fiery explosion
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
+            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
             break;
         }
         case 'ICE': {
@@ -17,10 +24,10 @@ function spawnImpact(state, b) {
             // icy spikes
             for (let n = 0; n < 4; n++) {
                 const ang = rng() * Math.PI * 2;
-                state.particles.push({ x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
-                state.particles.push({ x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+                addParticle(state, { x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+                addParticle(state, { x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
             }
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
             break;
         }
         case 'LIGHT': {
@@ -29,24 +36,24 @@ function spawnImpact(state, b) {
             for (let n = 0; n < 6; n++) {
                 const ang = rng() * Math.PI * 2;
                 const sp = 160;
-                state.particles.push({
+                addParticle(state, {
                     x: b.x, y: b.y,
                     vx: Math.cos(ang) * sp,
                     vy: Math.sin(ang) * sp,
                     ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#faf5ff', spark: true,
                 });
             }
-            state.particles.push({ x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
+            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
             break;
         }
         case 'POISON':
             count = 7; speed = 45; ttl = 0.6; ring = 16; break;
     }
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
+    addParticle(state, { x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
     for (let n = 0; n < count; n++) {
         const ang = rng() * Math.PI * 2;
         const sp = speed * (0.5 + rng());
-        state.particles.push({
+        addParticle(state, {
             x: b.x, y: b.y,
             vx: Math.cos(ang) * sp,
             vy: Math.sin(ang) * sp,

--- a/packages/core/particles.js
+++ b/packages/core/particles.js
@@ -1,6 +1,17 @@
 // packages/core/particles.js
 // Simple particle updater for bullet impact effects
 
+const pool = [];
+
+export function acquireParticle() {
+    return pool.pop() || {};
+}
+
+export function releaseParticle(p) {
+    for (const k in p) delete p[k];
+    pool.push(p);
+}
+
 export function updateParticles(state) {
     for (let i = state.particles.length - 1; i >= 0; i--) {
         const p = state.particles[i];
@@ -9,6 +20,10 @@ export function updateParticles(state) {
         if (p.vy) p.y += p.vy * state.dt;
         if (p.vr) p.r += p.vr * state.dt;
         p.a = p.ttl / p.max;
-        if (p.ttl <= 0) state.particles.splice(i, 1);
+        if (p.ttl <= 0) {
+            const last = state.particles.pop();
+            if (last !== p) state.particles[i] = last;
+            releaseParticle(p);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a simple object pool for particles and helpers to acquire or release from the pool
- use particle pool in bullet impact effect spawning
- recycle expired particles back into pool during particle updates

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a7fe01ebe483309d6ec968109178f6