### PR TITLE
docs: add guide for new elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# TD Engine
+
+Core modules for a small tower defense engine.
+
+## Documentation
+- [Adding elements](docs/ADDING_ELEMENTS.md)

--- a/docs/ADDING_ELEMENTS.md
+++ b/docs/ADDING_ELEMENTS.md
@@ -1,0 +1,59 @@
+# Adding Elements
+
+This guide shows how to introduce a new damage element to the engine.
+
+## 1. Define the element
+
+Each element lives in `packages/core/elements.js` and includes a `color` used for rendering and a `status` effect applied on hit.
+
+```js
+// packages/core/elements.js
+export const elements = {
+  FIRE:  { color:"#ef4444", status:"BURN" },
+  ICE:   { color:"#38bdf8", status:"CHILL" },
+  LIGHT: { color:"#a78bfa", status:"SHOCK" },
+  POISON:{ color:"#22c55e", status:"POISON" },
+  EARTH: { color:"#a3a3a3", status:"BRITTLE" },
+  WIND:  { color:"#60a5fa", status:"EXPOSED" },
+  // ARCANE: { color:"#be123c", status:"MANA_BURN" }, // example addition
+};
+```
+
+Add a new entry following the same shape. `color` should be any CSS color string, and `status` refers to the effect to apply.
+
+## 2. Register the status effect
+
+Status behaviours are defined in the effect registry at `packages/core/combat.js`. Extend `applyStatus` with your new status and update `tickStatusesAndCombos` so it expires correctly.
+
+```js
+// packages/core/combat.js
+import { Status } from './content.js';
+
+export function applyStatus(c, status, fromTower) {
+    const m = fromTower?.mod || {};
+    if (status === Status.BURN) {
+        c.status[Status.BURN] = { t: 2.2 * (1 + (m.burn || 0)), dot: 5 * (1 + (m.burn || 0)) };
+    }
+    // ...existing effects...
+    if (status === Status.MANA_BURN) {
+        c.status[Status.MANA_BURN] = { t: 2.0, dot: 10 };
+    }
+}
+
+export function tickStatusesAndCombos(c, dt) {
+    if (c.status[Status.MANA_BURN]) {
+        const s = c.status[Status.MANA_BURN];
+        s.t -= dt; c.hp -= s.dot * dt;
+        if (s.t <= 0) delete c.status[Status.MANA_BURN];
+    }
+    // ...existing timers...
+}
+```
+
+`Status` constants live in `packages/core/content.js`; add an identifier there so the engine can reference your effect.
+
+## 3. Optional: combos and content
+
+If the new status should interact with others, update `packages/core/combos.js`. You may also want to add tower blueprints or loot referencing the element in `packages/core/content.js`.
+
+With these steps, the engine recognises your element, applies its status effect, and renders it using the specified colour.


### PR DESCRIPTION
## Summary
- document how to define new elements and status effects
- add link to docs from README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fe033c1483309dc450dbdfe0f4bf