### PR TITLE
Add creep death animation

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -4,6 +4,7 @@
 import { cellCenterForMap } from './map.js';
 import { astar } from './pathfinding.js';
 import { tickStatusesAndCombos } from './combat.js';
+import { spawnDeathParticles } from './particles.js';
 
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
@@ -46,6 +47,7 @@ export function cullDead(state, { onKill }) {
         state.gold += c.gold;
         state.score += 3;
         onKill?.(c);
+        spawnDeathParticles(state, c);
       }
       state.creeps.splice(i, 1);
     }

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -6,6 +6,7 @@ import { defaultWaveConfig, createWaveController } from './waves.js';
 import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
 import { fireTower } from './towers.js';
 import { updateBullets } from './bullets.js';
+import { updateParticles } from './particles.js';
 import { astar } from './pathfinding.js';
 import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
@@ -219,6 +220,8 @@ export function createEngine(seedState) {
         cullDead(state, {
             onKill: (c) => { onCreepKill(c); onGoldChange(+c.gold, 'kill'); },
         });
+
+        updateParticles(state);
 
         const canAuto = state.autoWaveEnabled && !state.gameOver && !waves.isSpawning() && state.creeps.length === 0;
         if (canAuto) {

--- a/packages/core/particles.js
+++ b/packages/core/particles.js
@@ -1,0 +1,30 @@
+// packages/core/particles.js
+// Simple particle helpers for transient effects.
+
+export function spawnDeathParticles(state, creep) {
+    state.particles.push({
+        x: creep.x,
+        y: creep.y,
+        r: 0,
+        a: 0.6,
+        ttl: 0.3,
+        ring: true,
+        color: '#f87171',
+    });
+}
+
+export function updateParticles(state) {
+    for (let i = state.particles.length - 1; i >= 0; i--) {
+        const p = state.particles[i];
+        if (p.ring) {
+            p.r += 60 * state.dt;
+        }
+        if (typeof p.a === 'number') {
+            p.a -= state.dt * 2;
+        }
+        p.ttl -= state.dt;
+        if (p.ttl <= 0 || (typeof p.a === 'number' && p.a <= 0)) {
+            state.particles.splice(i, 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add particle helper to render a fading ring when a creep dies
- update engine and creep logic to spawn and step particles

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e8ad33a48330882b6e3dbda2b8df