### PR TITLE
feat: add modular creep death effects

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -4,6 +4,7 @@
 import { cellCenterForMap } from './map.js';
 import { astar } from './pathfinding.js';
 import { tickStatusesAndCombos } from './combat.js';
+import { getDeathFx } from './deaths/index.js';
 
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
@@ -44,6 +45,7 @@ export function cullDead(state, { onKill }) {
       if (c.hp <= 0) {
         state.gold += c.gold;
         state.score += 3;
+        getDeathFx(c.type).die(state, c);
         onKill?.(c);
       }
       state.creeps.splice(i, 1);

--- a/packages/core/deaths/boss.js
+++ b/packages/core/deaths/boss.js
@@ -1,0 +1,20 @@
+// packages/core/deaths/boss.js
+import base from './default.js';
+
+function die(state, c) {
+    base.die(state, c);
+    const rng = state.rng;
+    // boss explodes into many fragments
+    for (let n = 0; n < 24; n++) {
+        const ang = rng() * Math.PI * 2;
+        const sp = 60 + rng() * 80;
+        state.particles.push({
+            x: c.x, y: c.y,
+            vx: Math.cos(ang) * sp,
+            vy: Math.sin(ang) * sp,
+            ttl: 0.6, max: 0.6, a: 1, color: '#fbbf24',
+        });
+    }
+}
+
+export default { die };

--- a/packages/core/deaths/default.js
+++ b/packages/core/deaths/default.js
@@ -1,0 +1,9 @@
+// packages/core/deaths/default.js
+// Generic death effect for creeps
+
+function die(state, c) {
+    // simple fade out ring
+    state.particles.push({ x: c.x, y: c.y, r: 0, vr: 80, ttl: 0.4, max: 0.4, a: 1, color: '#94a3b8', circle: true });
+}
+
+export default { die };

--- a/packages/core/deaths/index.js
+++ b/packages/core/deaths/index.js
@@ -1,0 +1,13 @@
+// packages/core/deaths/index.js
+import def from './default.js';
+import boss from './boss.js';
+
+const registry = {
+    Boss: boss,
+};
+
+export function getDeathFx(type) {
+    return registry[type] || def;
+}
+
+export { registry };


### PR DESCRIPTION
## Summary
- add particle-based creep death effects with registry per creep type
- trigger death effects when a creep is killed
- include flashy boss death example

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8047c490083308efa31d7c1881181