### PR TITLE
Add base ARCHER and SIEGE tower support

### DIFF
--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -7,10 +7,25 @@ export const GRID_H = 16;
 export const START = { x: 0, y: 8 };
 export const END = { x: 23, y: 8 };
 
-export const Elt = { FIRE: 'FIRE', ICE: 'ICE', LIGHT: 'LIGHT', POISON: 'POISON' };
+// Base tower identifiers.  Non-elemental towers such as ARCHER and SIEGE are
+// included alongside the elemental types.  The CANNON key is provided as an
+// alias for SIEGE so callers can use either term.
+export const Elt = {
+  FIRE: 'FIRE',
+  ICE: 'ICE',
+  LIGHT: 'LIGHT',
+  POISON: 'POISON',
+  ARCHER: 'ARCHER',
+  SIEGE: 'SIEGE',
+  CANNON: 'SIEGE',
+};
 export const Status = { BURN: 'BURN', CHILL: 'CHILL', SHOCK: 'SHOCK', POISON: 'POISON' };
 
+// Tower definitions used to derive helpers like EltColor, EltType and
+// EltStatus.  Non-elemental towers simply omit a status effect.
 export const ELEMENTS = [
+  { key: 'ARCHER', color: '#9ca3af', type: 'bolt' },
+  { key: 'SIEGE', color: '#f59e0b', type: 'siege' },
   { key: 'FIRE', color: '#ef4444', type: 'splash', status: Status.BURN },
   { key: 'ICE', color: '#38bdf8', type: 'bolt', status: Status.CHILL },
   { key: 'LIGHT', color: '#a78bfa', type: 'chain', status: Status.SHOCK },
@@ -21,7 +36,15 @@ export const EltColor = Object.fromEntries(ELEMENTS.map(e => [e.key, e.color]));
 export const EltType = Object.fromEntries(ELEMENTS.map(e => [e.key, e.type]));
 export const EltStatus = Object.fromEntries(ELEMENTS.map(e => [e.key, e.status]));
 
-export const COST = { FIRE: 70, ICE: 70, LIGHT: 90, POISON: 75 };
+// Base towers are cheaper while elemental towers command a premium.
+export const COST = {
+  ARCHER: 40,
+  SIEGE: 60,
+  FIRE: 70,
+  ICE: 70,
+  LIGHT: 90,
+  POISON: 75,
+};
 export const UPG_COST = (lvl) => 80 + lvl * 45;
 export const UNLOCK_TIERS = [2, 4, 6];
 //export const EVO_COST = tier => [120, 220, 400][tier] || 500;
@@ -35,6 +58,8 @@ export const ResistProfiles = {
 };
 
 export const BLUEPRINT = {
+  ARCHER: { range: 110, firerate: 1.0, dmg: 7, type: 'bolt' },
+  SIEGE: { range: 120, firerate: 0.6, dmg: 20, type: 'siege' },
   FIRE: { range: 120, firerate: 0.8, dmg: 22, type: 'splash', status: Status.BURN },
   ICE: { range: 130, firerate: 0.95, dmg: 12, type: 'bolt', status: Status.CHILL },
   LIGHT: { range: 140, firerate: 0.7, dmg: 18, type: 'chain', status: Status.SHOCK },

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -67,7 +67,10 @@ export function createEngine(seedState) {
         return true;
     }
 
-    function placeTower(gx, gy, elt) {
+    const normalizeElt = (e) => (e === Elt.CANNON ? Elt.SIEGE : e);
+
+    function placeTower(gx, gy, rawElt) {
+        const elt = normalizeElt(rawElt);
         if (!inBounds(gx, gy)) return { ok: false, reason: 'oob' };
         if (state.towers.some(t => t.gx === gx && t.gy === gy)) return { ok: false, reason: 'occupied' };
         const { start, end } = state.map;
@@ -77,9 +80,10 @@ export function createEngine(seedState) {
         if (!canPlace(gx, gy)) return { ok: false, reason: 'blocks_path' };
 
         const cost = COST[elt];
+        const bp = BLUEPRINT[elt];
+        if (cost == null || !bp) return { ok: false, reason: 'invalid_tower' };
         if (state.gold < cost) return { ok: false, reason: 'gold' };
 
-        const bp = BLUEPRINT[elt];
         const t = {
             id: uuid(), gx, gy,
             x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2,
@@ -115,7 +119,7 @@ export function createEngine(seedState) {
         return true;
     }
 
-    function setBuild(elt) { state.buildSel = elt; }
+    function setBuild(elt) { state.buildSel = normalizeElt(elt); }
 
     function setHover(gx, gy) {
         state.hover.gx = gx; state.hover.gy = gy;

--- a/packages/core/stats.js
+++ b/packages/core/stats.js
@@ -36,7 +36,9 @@ export function attachStats(engine) {
     });
 
     on('towerPlace', ({ id, elt, cost }) => {
-        ensureTower(id, elt).placedAt = performance.now();
+        const t = ensureTower(id, elt);
+        t.placedAt = performance.now();
+        t.cost = cost || 0;
         stats.totals.goldSpent += cost || 0;
     });
 
@@ -147,7 +149,7 @@ export function attachStats(engine) {
     }
     function freshWave(wave) { return { wave, kills: 0, leaks: 0, rewardGold: 0, durationMs: 0, combos: 0, creepsSpawned: 0 }; }
     function ensureTower(id, elt) {
-        const t = (stats.towers[id] ||= { id, elt: elt || null, placedAt: 0, soldAt: 0, levelUps: 0, finalLevel: 1, evolutions: [], shots: 0, hits: 0, damage: 0, damageByElt: {}, refund: 0 });
+        const t = (stats.towers[id] ||= { id, elt: elt || null, placedAt: 0, soldAt: 0, levelUps: 0, finalLevel: 1, evolutions: [], shots: 0, hits: 0, damage: 0, damageByElt: {}, refund: 0, cost: 0 });
         if (elt && !t.elt) t.elt = elt;
         return t;
     }

--- a/packages/core/towers.js
+++ b/packages/core/towers.js
@@ -178,10 +178,35 @@ function splashStrategy(state, { onShot }, t, target, dmg) {
     t.cooldown = 1 / t.firerate;
 }
 
+// Siege/cannon towers lob heavy projectiles with a wider explosion radius
+// and slower travel speed than standard splash towers.
+function siegeStrategy(state, { onShot }, t, target, dmg) {
+    const dx = target.x - t.x, dy = target.y - t.y;
+    const dist = Math.hypot(dx, dy);
+    const speed = 180; // slower projectile
+    state.bullets.push({
+        kind: 'splash',
+        x: t.x, y: t.y,
+        vx: (dx / dist) * speed,
+        vy: (dy / dist) * speed,
+        ttl: dist / speed,
+        aoe: 50 + (t.mod.splash ? 24 : 0),
+        color: EltColor[t.elt],
+        fromId: t.id,
+        elt: t.elt,
+        status: t.status,
+        dmg,
+    });
+    state.shots++;
+    onShot?.(t.id);
+    t.cooldown = 1 / t.firerate;
+}
+
 const STRATEGIES = {
     bolt: boltStrategy,
     chain: chainStrategy,
     splash: splashStrategy,
+    siege: siegeStrategy,
 };
 
 export function fireTower(state, callbacks, t, dt) {


### PR DESCRIPTION
## Summary
- add ARCHER and SIEGE/CANNON tower definitions with costs and blueprints
- normalize cannon selection, validate tower lookups and add siege firing strategy
- track tower placement cost in stats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "import('./packages/core/engine.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`


------
https://chatgpt.com/codex/tasks/task_e_68a806c6a71c833088299487fadd554b