### PR TITLE
feat: add UI support for new towers

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -160,10 +160,15 @@ wirePaletteButtons(document);
 // Hotkeys
 window.addEventListener('keydown', (e) => {
   let changed = false;
-  if (e.code === 'Digit1') { engine.setBuild('FIRE'); changed = true; }
-  if (e.code === 'Digit2') { engine.setBuild('ICE'); changed = true; }
-  if (e.code === 'Digit3') { engine.setBuild('LIGHT'); changed = true; }
-  if (e.code === 'Digit4') { engine.setBuild('POISON'); changed = true; }
+  if (e.code === 'Digit1') { engine.setBuild('ARCHER'); changed = true; }
+  if (e.code === 'Digit2') { engine.setBuild('SIEGE'); changed = true; }
+  if (e.code === 'Digit3') { engine.setBuild('FIRE'); changed = true; }
+  if (e.code === 'Digit4') { engine.setBuild('ICE'); changed = true; }
+  if (e.code === 'Digit5') { engine.setBuild('LIGHT'); changed = true; }
+  if (e.code === 'Digit6') { engine.setBuild('POISON'); changed = true; }
+  if (e.code === 'Digit7') { engine.setBuild('EARTH'); changed = true; }
+  if (e.code === 'Digit8') { engine.setBuild('WIND'); changed = true; }
+  if (e.code === 'Digit9') { engine.setBuild('ARCANE'); changed = true; }
   if (e.code === 'Space') engine.startWave();
   if (e.code === 'KeyP') engine.setPaused(!engine.state.paused);
   if (e.code === 'KeyF') engine.toggleFast();

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -76,11 +76,16 @@
     <!-- Sidebar: desktop only -->
     <aside class="col-span-12 md:col-span-4 space-y-2 hidden md:block">
       <div class="text-xs uppercase">Build</div>
-      <div class="grid grid-cols-4 gap-2">
+      <div class="grid grid-cols-3 gap-2">
+        <button data-elt="ARCHER" class="px-2 py-2 border rounded">Archer</button>
+        <button data-elt="SIEGE" class="px-2 py-2 border rounded">Siege</button>
         <button data-elt="FIRE" class="px-2 py-2 border rounded">Fire</button>
         <button data-elt="ICE" class="px-2 py-2 border rounded">Ice</button>
         <button data-elt="LIGHT" class="px-2 py-2 border rounded">Lightning</button>
         <button data-elt="POISON" class="px-2 py-2 border rounded">Poison</button>
+        <button data-elt="EARTH" class="px-2 py-2 border rounded">Earth</button>
+        <button data-elt="WIND" class="px-2 py-2 border rounded">Wind</button>
+        <button data-elt="ARCANE" class="px-2 py-2 border rounded">Arcane</button>
       </div>
       <div id="towerInfo" class="text-sm border rounded p-2 min-h-[140px]">—</div>
     </aside>
@@ -98,11 +103,16 @@
       </div>
       <div class="text-xs opacity-80">Gold <span data-bind="gold">-</span> • Lives <span data-bind="lives">-</span> •
         Wave <span data-bind="wave">-</span></div>
-      <div class="grid grid-cols-4 gap-2 ml-2">
+      <div class="grid grid-cols-3 gap-2 ml-2">
+        <button data-elt="ARCHER" class="px-3 py-2 border rounded text-xs">Archer</button>
+        <button data-elt="SIEGE" class="px-3 py-2 border rounded text-xs">Siege</button>
         <button data-elt="FIRE" class="px-3 py-2 border rounded text-xs">Fire</button>
         <button data-elt="ICE" class="px-3 py-2 border rounded text-xs">Ice</button>
         <button data-elt="LIGHT" class="px-3 py-2 border rounded text-xs">Lightning</button>
         <button data-elt="POISON" class="px-3 py-2 border rounded text-xs">Poison</button>
+        <button data-elt="EARTH" class="px-3 py-2 border rounded text-xs">Earth</button>
+        <button data-elt="WIND" class="px-3 py-2 border rounded text-xs">Wind</button>
+        <button data-elt="ARCANE" class="px-3 py-2 border rounded text-xs">Arcane</button>
       </div>
     </div>
   </div>

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -27,7 +27,7 @@ export function createInitialState(seedState) {
         autoWaveDelay: 1200,
         _autoWaveTimer: -1,
 
-        buildSel: Elt.FIRE,
+        buildSel: Elt.ARCHER,
 
         towers: [],
         creeps: [],


### PR DESCRIPTION
## Summary
- add UI buttons for Archer, Siege, Earth, Wind, and Arcane towers
- expand hotkeys to select all towers
- default build selection to Archer

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a809dfd51883309f17315f720db356