### PR TITLE
Expose new towers in example UI

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -164,6 +164,11 @@ window.addEventListener('keydown', (e) => {
   if (e.code === 'Digit2') { engine.setBuild('ICE'); changed = true; }
   if (e.code === 'Digit3') { engine.setBuild('LIGHT'); changed = true; }
   if (e.code === 'Digit4') { engine.setBuild('POISON'); changed = true; }
+  if (e.code === 'Digit5') { engine.setBuild('EARTH'); changed = true; }
+  if (e.code === 'Digit6') { engine.setBuild('WIND'); changed = true; }
+  if (e.code === 'Digit7') { engine.setBuild('ARCANE'); changed = true; }
+  if (e.code === 'Digit8') { engine.setBuild('ARCHER'); changed = true; }
+  if (e.code === 'Digit9') { engine.setBuild('SIEGE'); changed = true; }
   if (e.code === 'Space') engine.startWave();
   if (e.code === 'KeyP') engine.setPaused(!engine.state.paused);
   if (e.code === 'KeyF') engine.toggleFast();

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -81,10 +81,15 @@
         <button data-elt="ICE" class="px-2 py-2 border rounded">Ice</button>
         <button data-elt="LIGHT" class="px-2 py-2 border rounded">Lightning</button>
         <button data-elt="POISON" class="px-2 py-2 border rounded">Poison</button>
-      </div>
-      <div id="towerInfo" class="text-sm border rounded p-2 min-h-[140px]">—</div>
-    </aside>
-  </div>
+        <button data-elt="EARTH" class="px-2 py-2 border rounded">Earth</button>
+        <button data-elt="WIND" class="px-2 py-2 border rounded">Wind</button>
+        <button data-elt="ARCANE" class="px-2 py-2 border rounded">Arcane</button>
+        <button data-elt="ARCHER" class="px-2 py-2 border rounded">Archer</button>
+        <button data-elt="SIEGE" class="px-2 py-2 border rounded">Siege</button>
+        </div>
+        <div id="towerInfo" class="text-sm border rounded p-2 min-h-[140px]">—</div>
+      </aside>
+    </div>
 
   <!-- Mobile bottom toolbar (single source of truth on mobile) -->
   <div
@@ -98,14 +103,19 @@
       </div>
       <div class="text-xs opacity-80">Gold <span data-bind="gold">-</span> • Lives <span data-bind="lives">-</span> •
         Wave <span data-bind="wave">-</span></div>
-      <div class="grid grid-cols-4 gap-2 ml-2">
-        <button data-elt="FIRE" class="px-3 py-2 border rounded text-xs">Fire</button>
-        <button data-elt="ICE" class="px-3 py-2 border rounded text-xs">Ice</button>
-        <button data-elt="LIGHT" class="px-3 py-2 border rounded text-xs">Lightning</button>
-        <button data-elt="POISON" class="px-3 py-2 border rounded text-xs">Poison</button>
+        <div class="grid grid-cols-4 gap-2 ml-2">
+          <button data-elt="FIRE" class="px-3 py-2 border rounded text-xs">Fire</button>
+          <button data-elt="ICE" class="px-3 py-2 border rounded text-xs">Ice</button>
+          <button data-elt="LIGHT" class="px-3 py-2 border rounded text-xs">Lightning</button>
+          <button data-elt="POISON" class="px-3 py-2 border rounded text-xs">Poison</button>
+          <button data-elt="EARTH" class="px-3 py-2 border rounded text-xs">Earth</button>
+          <button data-elt="WIND" class="px-3 py-2 border rounded text-xs">Wind</button>
+          <button data-elt="ARCANE" class="px-3 py-2 border rounded text-xs">Arcane</button>
+          <button data-elt="ARCHER" class="px-3 py-2 border rounded text-xs">Archer</button>
+          <button data-elt="SIEGE" class="px-3 py-2 border rounded text-xs">Siege</button>
+        </div>
       </div>
     </div>
-  </div>
 
   <!-- Game Over Modal -->
   <div id="goModal" class="fixed inset-0 hidden items-center justify-center z-50">


### PR DESCRIPTION
## Summary
- Add Earth, Wind, Arcane, Archer, and Siege tower options to example palette and mobile toolbar
- Map hotkeys 5-9 to the new tower types

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a809dfd51883309f17315f720db356