### PR TITLE
Fix siege tower build failure

### DIFF
--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -48,7 +48,9 @@ export const EltType = Object.fromEntries(ELEMENTS.map(e => [e.key, e.type]));
 export const EltStatus = Object.fromEntries(ELEMENTS.map(e => [e.key, e.status]));
 
 // Non-elemental/basic towers that don't inflict statuses
-export const BASIC_TOWERS = ['ARCHER', 'CANNON'];
+// Include legacy 'CANNON' for backwards compatibility, but the
+// canonical name is 'SIEGE'.
+export const BASIC_TOWERS = ['ARCHER', 'SIEGE', 'CANNON'];
 
 // Upgrade cost now varies by tower category; `elt` is optional for backwards compat
 export const UPG_COST = (lvl, elt) => {
@@ -131,7 +133,10 @@ export const ResistProfiles = {
 
 export const BLUEPRINT = {
   ARCHER: { range: 110, firerate: 1.1, dmg: 9, type: 'bolt', status: null },
-  CANNON: { range: 120, firerate: 0.75, dmg: 16, type: 'splash', status: null },
+  // Siege towers are the renamed cannon towers. They fire heavy shells
+  // with a wider explosion radius. Keep a CANNON alias for older saves.
+  SIEGE: { range: 120, firerate: 0.75, dmg: 16, type: 'siege', status: null },
+  CANNON: { range: 120, firerate: 0.75, dmg: 16, type: 'siege', status: null },
   FIRE: { range: 120, firerate: 0.8, dmg: 22, type: 'splash', status: Status.BURN },
   ICE: { range: 130, firerate: 0.95, dmg: 12, type: 'bolt', status: Status.CHILL },
   LIGHT: { range: 140, firerate: 0.7, dmg: 18, type: 'chain', status: Status.SHOCK },

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -67,7 +67,8 @@ export function createEngine(seedState) {
         return true;
     }
 
-    const normalizeElt = (e) => (e === Elt.CANNON ? Elt.SIEGE : e);
+    // Handle legacy 'CANNON' tower name by normalizing it to 'SIEGE'.
+    const normalizeElt = (e) => (e === 'CANNON' ? Elt.SIEGE : e);
 
     function placeTower(gx, gy, rawElt) {
         const elt = normalizeElt(rawElt);


### PR DESCRIPTION
## Summary
- register siege tower blueprint and basic tower alias
- normalize legacy `CANNON` element to `SIEGE`

## Testing
- `node -e "import {createEngine} from './packages/core/engine.js';const engine=createEngine();engine.loadMap({size:{cols:3,rows:3},start:{x:0,y:0},end:{x:2,y:2},terrain:[[0,0,0],[0,0,0],[0,0,0]]});console.log(engine.placeTower(1,1,'SIEGE'));"`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a80b4081b48330856bded94673cdc9