### PR TITLE
Add water tower with aquarelle projectile effect

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -169,6 +169,7 @@ window.addEventListener('keydown', (e) => {
   if (e.code === 'Digit7') { engine.setBuild('EARTH'); changed = true; }
   if (e.code === 'Digit8') { engine.setBuild('WIND'); changed = true; }
   if (e.code === 'Digit9') { engine.setBuild('ARCANE'); changed = true; }
+  if (e.code === 'Digit0') { engine.setBuild('WATER'); changed = true; }
   if (e.code === 'Space') engine.startWave();
   if (e.code === 'KeyP') engine.setPaused(!engine.state.paused);
   if (e.code === 'KeyF') engine.toggleFast();

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -85,6 +85,7 @@
         <button data-elt="POISON" class="px-2 py-2 border rounded">Poison</button>
         <button data-elt="EARTH" class="px-2 py-2 border rounded">Earth</button>
         <button data-elt="WIND" class="px-2 py-2 border rounded">Wind</button>
+        <button data-elt="WATER" class="px-2 py-2 border rounded">Water</button>
         <button data-elt="ARCANE" class="px-2 py-2 border rounded">Arcane</button>
       </div>
       <div id="towerInfo" class="text-sm border rounded p-2 min-h-[140px]">—</div>
@@ -112,6 +113,7 @@
         <button data-elt="POISON" class="px-3 py-2 border rounded text-xs">Poison</button>
         <button data-elt="EARTH" class="px-3 py-2 border rounded text-xs">Earth</button>
         <button data-elt="WIND" class="px-3 py-2 border rounded text-xs">Wind</button>
+        <button data-elt="WATER" class="px-3 py-2 border rounded text-xs">Water</button>
         <button data-elt="ARCANE" class="px-3 py-2 border rounded text-xs">Arcane</button>
       </div>
     </div>

--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -17,6 +17,7 @@ export const Elt = {
   CANNON: 'SIEGE',
   EARTH: 'EARTH',
   WIND: 'WIND',
+  WATER: 'WATER',
   ARCANE: 'ARCANE'
 };
 export const Status = {
@@ -40,6 +41,7 @@ export const ELEMENTS = [
   { key: 'POISON', color: '#22c55e', type: 'bolt', status: Status.POISON },
   { key: 'EARTH', color: '#a3a3a3', type: 'splash', status: Status.BRITTLE },
   { key: 'WIND', color: '#60a5fa', type: 'bolt', status: Status.EXPOSED },
+  { key: 'WATER', color: '#3b82f6', type: 'splash' },
   { key: 'ARCANE', color: '#be123c', type: 'bolt', status: Status.MANA_BURN }
 ];
 
@@ -77,6 +79,7 @@ export const COST = {
   POISON: 95,
   EARTH: 100,
   WIND: 100,
+  WATER: 90,
   ARCANE: 120
 };
 export const UNLOCK_TIERS = [2, 4, 6];
@@ -86,13 +89,13 @@ export const ResistProfiles = {
   Grunt: {
     hp: 95,
     speed: 40,
-    resist: { FIRE: 0.1, ICE: 0, LIGHT: 0, POISON: 0, EARTH: 0, WIND: 0, ARCANE: 0 },
+    resist: { FIRE: 0.1, ICE: 0, LIGHT: 0, POISON: 0, EARTH: 0, WIND: 0, WATER: 0, ARCANE: 0 },
     gold: 8
   },
   Runner: {
     hp: 70,
     speed: 70,
-    resist: { FIRE: 0, ICE: 0.1, LIGHT: 0, POISON: 0, EARTH: 0, WIND: 0, ARCANE: 0 },
+    resist: { FIRE: 0, ICE: 0.1, LIGHT: 0, POISON: 0, EARTH: 0, WIND: 0, WATER: 0, ARCANE: 0 },
     gold: 7
   },
   Tank: {
@@ -105,6 +108,7 @@ export const ResistProfiles = {
       POISON: 0.15,
       EARTH: 0.15,
       WIND: 0.15,
+      WATER: 0.15,
       ARCANE: 0.15
     },
     gold: 16
@@ -112,7 +116,7 @@ export const ResistProfiles = {
   Shield: {
     hp: 120,
     speed: 42,
-    resist: { FIRE: 0.25, ICE: 0.1, LIGHT: 0.25, POISON: 0, EARTH: 0.2, WIND: 0.2, ARCANE: 0 },
+    resist: { FIRE: 0.25, ICE: 0.1, LIGHT: 0.25, POISON: 0, EARTH: 0.2, WIND: 0.2, WATER: 0, ARCANE: 0 },
     gold: 10
   },
   Boss: {
@@ -125,6 +129,7 @@ export const ResistProfiles = {
       POISON: 0.2,
       EARTH: 0.2,
       WIND: 0.2,
+      WATER: 0.2,
       ARCANE: 0.2
     },
     gold: 90
@@ -143,6 +148,7 @@ export const BLUEPRINT = {
   POISON: { range: 120, firerate: 1.0, dmg: 8, type: 'bolt', status: Status.POISON },
   EARTH: { range: 135, firerate: 0.9, dmg: 22, type: 'splash', status: Status.BRITTLE },
   WIND: { range: 160, firerate: 0.65, dmg: 16, type: 'bolt', status: Status.EXPOSED },
+  WATER: { range: 125, firerate: 0.9, dmg: 14, type: 'splash', status: null },
   ARCANE: { range: 145, firerate: 0.75, dmg: 18, type: 'bolt', status: Status.MANA_BURN }
 };
 

--- a/packages/render-canvas/aquarelle.js
+++ b/packages/render-canvas/aquarelle.js
@@ -1,0 +1,11 @@
+export function drawAquarelleBullet(ctx, { radius = 6, color = '#3b82f6' } = {}) {
+  // Simple watercolor-style circle using a radial gradient that fades to transparent.
+  const r = radius;
+  const g = ctx.createRadialGradient(0, 0, 0, 0, 0, r);
+  g.addColorStop(0, color);
+  g.addColorStop(1, 'rgba(59,130,246,0)');
+  ctx.fillStyle = g;
+  ctx.beginPath();
+  ctx.arc(0, 0, r, 0, Math.PI * 2);
+  ctx.fill();
+}

--- a/packages/render-canvas/index.js
+++ b/packages/render-canvas/index.js
@@ -3,6 +3,7 @@
 // plus calls to your existing entity renderers.
 
 import { TILE, EltColor } from '../core/content.js';
+import { drawAquarelleBullet } from './aquarelle.js';
 
 export function createCanvasRenderer({ ctx, engine, options = {} }) {
   const opts = {
@@ -202,6 +203,10 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
           ctx.bezierCurveTo(3, -2, 3, 4, 0, 5);
           ctx.bezierCurveTo(-3, 4, -3, -2, 0, -5);
           ctx.fill();
+          break;
+        }
+        case 'WATER': {
+          drawAquarelleBullet(ctx, { radius: b.r || 6, color });
           break;
         }
         case 'ARCHER': {


### PR DESCRIPTION
## Summary
- add water element and blueprint configuration
- render aquarelle-style projectiles
- expose water tower in example buttons and hotkeys

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a80bc3465c83308af748d7fe5f2868