### PR TITLE
Optimize core loop for better TD performance

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -75,21 +75,22 @@ export function updateBullets(state, { onCreepDamage }) {
         if (b.ttl <= 0) {
             if (b.kind === 'splash') {
                 let hitAny = false;
-                const fromT = state.towers.find(tt => tt.id === b.fromId);
                 for (const c of state.creeps) {
                     if (!c.alive) continue;
-                    if (Math.hypot(c.x - b.x, c.y - b.y) <= b.aoe) {
+                    const dx = c.x - b.x, dy = c.y - b.y;
+                    if (dx * dx + dy * dy <= b.aoe * b.aoe) {
                         takeDamage(c, b.dmg, b.elt, c.status.resShred || 0);
-                        applyStatus(c, b.status, fromT);
+                        applyStatus(c, b.status, { mod: b.mod });
                         hitAny = true;
-                        onCreepDamage?.({ creep: c, amount: b.dmg, elt: b.elt, towerId: fromT?.id });
+                        onCreepDamage?.({ creep: c, amount: b.dmg, elt: b.elt, towerId: b.fromId });
                     }
                 }
                 if (hitAny) state.hits++;
                 effect.aoe(state, b);
             }
             effect.impact(state, b);
-            state.bullets.splice(i, 1);
+            const last = state.bullets.pop();
+            if (i < state.bullets.length) state.bullets[i] = last;
         }
     }
 }

--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -31,11 +31,13 @@ export function advanceCreep(state, c, onLeak) {
   let A = c.path[c.seg], B = c.path[c.seg + 1];
   if (!B) { c.alive = false; state.lives--; onLeak(); return; }
 
-  const vx = B.x - A.x, vy = B.y - A.y;
-  const d = Math.hypot(vx, vy);
-  const dirx = vx / d, diry = vy / d;
-  c.x += dirx * speed * state.dt; c.y += diry * speed * state.dt; c.t += speed * state.dt;
-  if (c.t >= d) { c.seg++; c.t = 0; c.x = c.path[c.seg].x; c.y = c.path[c.seg].y; }
+  if (c._seg !== c.seg) {
+    const vx = B.x - A.x, vy = B.y - A.y;
+    const d = Math.sqrt(vx * vx + vy * vy);
+    c._dirx = vx / d; c._diry = vy / d; c._len = d; c._seg = c.seg;
+  }
+  c.x += c._dirx * speed * state.dt; c.y += c._diry * speed * state.dt; c.t += speed * state.dt;
+  if (c.t >= c._len) { c.seg++; c.t = 0; c.x = c.path[c.seg].x; c.y = c.path[c.seg].y; c._seg = c.seg - 1; }
 }
 
 export function cullDead(state, { onKill }) {

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -37,8 +37,13 @@ export function createEngine(seedState) {
     };
 
     function neighborsSynergy() {
+        const r2 = (2 * TILE + 1) * (2 * TILE + 1);
         for (const t of state.towers) {
-            const neighbors = state.towers.filter(o => o !== t && Math.hypot(o.x - t.x, o.y - t.y) <= 2 * TILE + 1);
+            const neighbors = state.towers.filter(o => {
+                if (o === t) return false;
+                const dx = o.x - t.x, dy = o.y - t.y;
+                return dx * dx + dy * dy <= r2;
+            });
             const uniq = new Set(neighbors.map(n => n.elt));
             t.synergy = 0.08 * uniq.size;
         }


### PR DESCRIPTION
## Summary
- Reduce distance calculations by using squared distances and `Math.sqrt` for towers and engine routines
- Cache creep path direction and length to avoid per-tick recomputation
- Streamline bullet handling by removing tower lookups, using squared distances, and O(1) removal

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a906b0236483308a819b31ecc343c2