### PR TITLE
feat: reuse shared path grid for creeps

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -2,20 +2,76 @@
 // Use map.start/end and map.size for pathing
 
 import { cellCenterForMap } from './map.js';
-import { astar } from './pathfinding.js';
 import { tickStatusesAndCombos } from './combat.js';
 import { getDeathFx } from './deaths/index.js';
 
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
-  const p = astar(start, end, isBlocked, size.cols, size.rows);
-  state.path = p ? p.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+  const { dist, prev } = buildPredecessorGrid(end, isBlocked, size.cols, size.rows);
+  state.pathGrid = { dist, prev };
+
+  const mainPathCells = reconstructPath(start, dist, prev, size);
+  state.path = mainPathCells ? mainPathCells.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+
   for (const c of state.creeps) {
     const startCell = toCell(state, c.x, c.y);
-    const blocker = (gx, gy) => (gx === startCell.gx && gy === startCell.gy) ? false : isBlocked(gx, gy);
-    const npcPath = astar({ x: startCell.gx, y: startCell.gy }, end, blocker, size.cols, size.rows);
-    if (npcPath) { c.path = npcPath.map(n => cellCenterForMap(state.map, n.x, n.y)); c.seg = 0; c.t = 0; }
+    const npcCells = reconstructPath({ x: startCell.gx, y: startCell.gy }, dist, prev, size);
+    if (npcCells) {
+      c.path = npcCells.map(n => cellCenterForMap(state.map, n.x, n.y));
+      c.seg = 0; c.t = 0;
+    }
   }
+}
+
+function buildPredecessorGrid(end, isBlocked, cols, rows) {
+  const dist = Array.from({ length: rows }, () => Array(cols).fill(Infinity));
+  const prev = Array.from({ length: rows }, () => Array(cols).fill(null));
+  const q = [{ x: end.x, y: end.y }];
+  dist[end.y][end.x] = 0;
+  const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+  while (q.length) {
+    const cur = q.shift();
+    const d = dist[cur.y][cur.x] + 1;
+    for (const [dx,dy] of dirs) {
+      const nx = cur.x + dx, ny = cur.y + dy;
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue;
+      if (isBlocked(nx, ny)) continue;
+      if (dist[ny][nx] !== Infinity) continue;
+      dist[ny][nx] = d;
+      prev[ny][nx] = cur;
+      q.push({ x: nx, y: ny });
+    }
+  }
+  return { dist, prev };
+}
+
+function reconstructPath(start, dist, prev, size) {
+  const { cols, rows } = size;
+  const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+  let x = start.x, y = start.y;
+  const path = [{ x, y }];
+
+  if (x < 0 || y < 0 || x >= cols || y >= rows) return null;
+
+  if (dist[y][x] === Infinity) {
+    let best = null, bestD = Infinity;
+    for (const [dx, dy] of dirs) {
+      const nx = x + dx, ny = y + dy;
+      if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue;
+      if (dist[ny][nx] < bestD) { bestD = dist[ny][nx]; best = { x: nx, y: ny }; }
+    }
+    if (!best || bestD === Infinity) return null;
+    x = best.x; y = best.y;
+    path.push({ x, y });
+  }
+
+  while (prev[y][x]) {
+    const p = prev[y][x];
+    x = p.x; y = p.y;
+    path.push({ x, y });
+  }
+
+  return path;
 }
 
 export function advanceCreep(state, c, onLeak) {

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -42,6 +42,7 @@ export function createInitialState(seedState) {
 
         path: [],
         pathPx: [],
+        pathGrid: null,
 
         gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
@@ -67,7 +68,7 @@ export function resetState(state, keep = {}) {
 
         towers: [], creeps: [], bullets: [], events: [], particles: [],
         selectedTowerId: null, hover: { gx: -1, gy: -1, valid: false },
-        path: [], pathPx: [], gameOver: false,
+        path: [], pathPx: [], pathGrid: null, gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
     });
 


### PR DESCRIPTION
## Summary
- build a predecessor grid with a single reverse BFS from the map end
- rebuild creep paths by walking this grid instead of per-creep A*
- store grid on state for reuse when pathing is recomputed

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a9264f55bc83309be97f613c919b63