### PR TITLE
feat: add spatial grid for creep queries

### DIFF
--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -2,6 +2,7 @@
 import { takeDamage, applyStatus } from './combat.js';
 import { acquireParticle } from './particles.js';
 import { getEffect } from './effects/index.js';
+import { queryCreeps } from './spatial.js';
 
 function addParticle(state, props) {
     const p = acquireParticle();
@@ -75,7 +76,8 @@ export function updateBullets(state, { onCreepDamage }) {
         if (b.ttl <= 0) {
             if (b.kind === 'splash') {
                 let hitAny = false;
-                for (const c of state.creeps) {
+                const nearby = queryCreeps(state, b.x, b.y, b.aoe);
+                for (const c of nearby) {
                     if (!c.alive) continue;
                     const dx = c.x - b.x, dy = c.y - b.y;
                     if (dx * dx + dy * dy <= b.aoe * b.aoe) {

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -11,6 +11,7 @@ import { astar } from './pathfinding.js';
 import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
 import { attachStats } from './stats.js';
+import { rebuildCreepGrid } from './spatial.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
 
@@ -235,6 +236,8 @@ export function createEngine(seedState) {
             });
             if (c.hp <= 0 && c.alive) { c.alive = false; }
         }
+
+        rebuildCreepGrid(state);
 
         for (const t of state.towers) { if (!t.ghost) fireTower(state, { onShot, onHit, onCreepDamage }, t, dt); }
 

--- a/packages/core/spatial.js
+++ b/packages/core/spatial.js
@@ -1,0 +1,40 @@
+// packages/core/spatial.js
+// Simple spatial grid for efficient creep queries shared between systems.
+
+const CELL = 40; // size of each grid cell in pixels
+
+// Rebuild the grid for all alive creeps. Call once per tick after movement.
+export function rebuildCreepGrid(state) {
+    state.creepCellSize = CELL;
+    const grid = new Map();
+    for (const c of state.creeps) {
+        if (!c.alive) continue;
+        const gx = Math.floor(c.x / CELL);
+        const gy = Math.floor(c.y / CELL);
+        const key = gx + ',' + gy;
+        let cell = grid.get(key);
+        if (!cell) { cell = []; grid.set(key, cell); }
+        cell.push(c);
+    }
+    state.creepGrid = grid;
+}
+
+// Return all creeps within radius r of point (x, y) using the grid.
+export function queryCreeps(state, x, y, r) {
+    const grid = state.creepGrid;
+    const cellSize = state.creepCellSize || CELL;
+    if (!grid) return state.creeps;
+    const minGx = Math.floor((x - r) / cellSize);
+    const maxGx = Math.floor((x + r) / cellSize);
+    const minGy = Math.floor((y - r) / cellSize);
+    const maxGy = Math.floor((y + r) / cellSize);
+    const result = [];
+    for (let gx = minGx; gx <= maxGx; gx++) {
+        for (let gy = minGy; gy <= maxGy; gy++) {
+            const cell = grid.get(gx + ',' + gy);
+            if (cell) result.push(...cell);
+        }
+    }
+    return result;
+}
+

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -34,6 +34,8 @@ export function createInitialState(seedState) {
         bullets: [],
         events: [],
         particles: [],
+        creepGrid: new Map(),
+        creepCellSize: 40,
 
         creepProfiles: seedState?.creepProfiles ?? structuredClone(ResistProfiles),
 
@@ -66,6 +68,7 @@ export function resetState(state, keep = {}) {
         autoWaveDelay: keep.autoWaveDelay ?? 1200, _autoWaveTimer: -1,
 
         towers: [], creeps: [], bullets: [], events: [], particles: [],
+        creepGrid: new Map(), creepCellSize: 40,
         selectedTowerId: null, hover: { gx: -1, gy: -1, valid: false },
         path: [], pathPx: [], gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },

--- a/packages/core/towers.js
+++ b/packages/core/towers.js
@@ -1,14 +1,16 @@
 // packages/core/towers.js
 import { EltColor, Status } from './content.js';
 import { takeDamage, applyStatus } from './combat.js';
+import { queryCreeps } from './spatial.js';
 
 export function targetInRange(state, t) {
     const mode = t.targeting || 'first';
+    const candidates = queryCreeps(state, t.x, t.y, t.range);
+    const r2 = t.range * t.range;
 
     if (mode === 'cycle') {
         const inRange = [];
-        const r2 = t.range * t.range;
-        for (const c of state.creeps) {
+        for (const c of candidates) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
             if (dx * dx + dy * dy <= r2) inRange.push(c);
@@ -24,8 +26,7 @@ export function targetInRange(state, t) {
     let best = null;
     if (mode === 'last') {
         let bestProg = Infinity;
-        const r2 = t.range * t.range;
-        for (const c of state.creeps) {
+        for (const c of candidates) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
             if (dx * dx + dy * dy <= r2) {
@@ -35,8 +36,7 @@ export function targetInRange(state, t) {
         }
     } else {
         let bestProg = -1;
-        const r2 = t.range * t.range;
-        for (const c of state.creeps) {
+        for (const c of candidates) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
             if (dx * dx + dy * dy <= r2) {
@@ -53,7 +53,8 @@ function handleNova(state, t, dt) {
     if (t.novaTimer <= 0) {
         t.novaTimer = freq;
         const r = t.range * 0.7, r2 = r * r;
-        for (const c of state.creeps) {
+        const nearby = queryCreeps(state, t.x, t.y, r);
+        for (const c of nearby) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
             if (dx * dx + dy * dy <= r2) applyStatus(c, Status.CHILL, t);
@@ -103,7 +104,8 @@ function attemptBoltHit(state, { onHit, onCreepDamage }, t, target, dmg, acc) {
             const dirx = target.x - t.x, diry = target.y - t.y; const len = Math.sqrt(dirx * dirx + diry * diry);
             const nx = dirx / len, ny = diry / len;
             let remaining = t.mod.pierce;
-            for (const c of state.creeps) {
+            const candidates = queryCreeps(state, t.x, t.y, len + 50);
+            for (const c of candidates) {
                 if (c === target || !c.alive) continue;
                 const proj = ((c.x - t.x) * nx + (c.y - t.y) * ny);
                 if (proj > 0 && proj < len + 50) {
@@ -134,7 +136,8 @@ function chainStrategy(state, callbacks, t, target, dmg, acc) {
     let bounces = 1 + (t.mod.chainBounce || 0); let last = target; let bounced = new Set([last.id]);
     let chainRange = 70 + (t.mod.chainRange || 0);
     while (bounces-- > 0) {
-    const next = state.creeps.find(c => {
+    const candidates = queryCreeps(state, last.x, last.y, chainRange);
+    const next = candidates.find(c => {
         if (!c.alive || bounced.has(c.id)) return false;
         const dx = c.x - last.x, dy = c.y - last.y;
         return dx * dx + dy * dy <= chainRange * chainRange;


### PR DESCRIPTION
## Summary
- add reusable spatial grid for creeps
- use spatial queries for tower targeting and splash bullets
- rebuild creep grid each tick in engine

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a92651fc088330827e7884fbabae2a