### PR TITLE
cache distance map for incremental path check

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -2,14 +2,16 @@
 // Use map.start/end and map.size for pathing
 
 import { cellCenterForMap } from './map.js';
-import { astar } from './pathfinding.js';
+import { astar, bfs } from './pathfinding.js';
 import { tickStatusesAndCombos } from './combat.js';
 import { getDeathFx } from './deaths/index.js';
 
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
-  const p = astar(start, end, isBlocked, size.cols, size.rows);
-  state.path = p ? p.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+  const { dist, path } = bfs(start, end, isBlocked, size.cols, size.rows);
+  state.pathCells = path || [];
+  state.path = path ? path.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+  state.dist = dist;
   for (const c of state.creeps) {
     const startCell = toCell(state, c.x, c.y);
     const blocker = (gx, gy) => (gx === startCell.gx && gy === startCell.gy) ? false : isBlocked(gx, gy);

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -7,7 +7,7 @@ import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
 import { fireTower } from './towers.js';
 import { updateBullets } from './bullets.js';
 import { updateParticles } from './particles.js';
-import { astar } from './pathfinding.js';
+import { bfs } from './pathfinding.js';
 import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
 import { attachStats } from './stats.js';
@@ -56,17 +56,17 @@ export function createEngine(seedState) {
         if (gx === end.x && gy === end.y) return false;
         if (!canBuildCell(gx, gy)) return false;
         if (state.towers.some(t => t.gx === gx && t.gy === gy)) return false;
-        const cached = state.path;
+        const cached = state.pathCells;
         const onPath = cached?.some(n => n.x === gx && n.y === gy);
         if (!cached || !cached.length || onPath) {
-            const p = astar(
+            const { path } = bfs(
                 state.map.start,
                 state.map.end,
                 (x, y) => (x === gx && y === gy) || isBlocked(x, y),
                 state.map.size.cols,
                 state.map.size.rows,
             );
-            return !!p;
+            return !!path;
         }
         // tile not on cached path; existing path remains valid
         return true;

--- a/packages/core/pathfinding.js
+++ b/packages/core/pathfinding.js
@@ -30,3 +30,45 @@ export function astar(start, end, isBlocked, cols, rows) {
     }
     return null;
 }
+
+// Simple BFS returning both a distance map and shortest path.
+// Distances use Infinity for unreachable cells.
+export function bfs(start, end, isBlocked, cols, rows) {
+    const inBounds = (x, y) => x >= 0 && y >= 0 && x < cols && y < rows;
+    const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+    const dist = Array.from({ length: rows }, () => Array(cols).fill(Infinity));
+    const prev = Array.from({ length: rows }, () => Array(cols).fill(null));
+    const q = [];
+    let qi = 0;
+
+    dist[start.y][start.x] = 0;
+    q.push({ x: start.x, y: start.y });
+
+    while (qi < q.length) {
+        const cur = q[qi++];
+        if (cur.x === end.x && cur.y === end.y) break;
+        for (const [dx, dy] of dirs) {
+            const nx = cur.x + dx, ny = cur.y + dy;
+            if (!inBounds(nx, ny) || isBlocked(nx, ny)) continue;
+            if (dist[ny][nx] !== Infinity) continue;
+            dist[ny][nx] = dist[cur.y][cur.x] + 1;
+            prev[ny][nx] = { x: cur.x, y: cur.y };
+            q.push({ x: nx, y: ny });
+        }
+    }
+
+    let path = null;
+    if (dist[end.y][end.x] !== Infinity) {
+        path = [];
+        let cur = { x: end.x, y: end.y };
+        while (cur) {
+            path.push({ x: cur.x, y: cur.y });
+            const p = prev[cur.y][cur.x];
+            cur = p;
+        }
+        path.reverse();
+    }
+
+    return { dist, path };
+}

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -40,8 +40,9 @@ export function createInitialState(seedState) {
         selectedTowerId: null,
         hover: { gx: -1, gy: -1, valid: false },
 
-        path: [],
-        pathPx: [],
+        path: [],        // pixel coordinates for main creep path
+        pathCells: [],   // grid coordinate path
+        dist: [],        // cached distance map
 
         gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
@@ -67,7 +68,7 @@ export function resetState(state, keep = {}) {
 
         towers: [], creeps: [], bullets: [], events: [], particles: [],
         selectedTowerId: null, hover: { gx: -1, gy: -1, valid: false },
-        path: [], pathPx: [], gameOver: false,
+        path: [], pathCells: [], dist: [], gameOver: false,
         stats: { leaks: 0, leakedByWave: {}, killsByTower: {}, wavesCleared: 0 },
     });
 


### PR DESCRIPTION
## Summary
- cache full-grid distance map via BFS
- reuse cached path in engine.canPlace and only recompute with BFS when blocking current path
- update state and path recomputation to store grid paths and distance map

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a92653d7308330b2b079f0b2607213