### PR TITLE
Optimize creep pathfinding queue

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -27,10 +27,11 @@ function buildPredecessorGrid(end, isBlocked, cols, rows) {
   const dist = Array.from({ length: rows }, () => Array(cols).fill(Infinity));
   const prev = Array.from({ length: rows }, () => Array(cols).fill(null));
   const q = [{ x: end.x, y: end.y }];
+  let head = 0;
   dist[end.y][end.x] = 0;
   const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
-  while (q.length) {
-    const cur = q.shift();
+  while (head < q.length) {
+    const cur = q[head++];
     const d = dist[cur.y][cur.x] + 1;
     for (const [dx,dy] of dirs) {
       const nx = cur.x + dx, ny = cur.y + dy;


### PR DESCRIPTION
## Summary
- Replace BFS queue shift calls with head-indexed queue for O(1) pops

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a950550ca083309e7959a6f18e3593