### PR TITLE
feat: optimize A* open set with min-heap

### DIFF
--- a/packages/core/minheap.js
+++ b/packages/core/minheap.js
@@ -1,0 +1,64 @@
+export class MinHeap {
+    constructor(compare = (a, b) => a - b) {
+        this.compare = compare;
+        this.heap = [];
+    }
+
+    size() {
+        return this.heap.length;
+    }
+
+    push(value) {
+        this.heap.push(value);
+        this._bubbleUp(this.heap.length - 1);
+    }
+
+    pop() {
+        if (this.heap.length === 0) return undefined;
+        const top = this.heap[0];
+        const end = this.heap.pop();
+        if (this.heap.length > 0) {
+            this.heap[0] = end;
+            this._sinkDown(0);
+        }
+        return top;
+    }
+
+    _bubbleUp(n) {
+        const element = this.heap[n];
+        while (n > 0) {
+            const parentN = Math.floor((n - 1) / 2);
+            const parent = this.heap[parentN];
+            if (this.compare(element, parent) >= 0) break;
+            this.heap[parentN] = element;
+            this.heap[n] = parent;
+            n = parentN;
+        }
+    }
+
+    _sinkDown(n) {
+        const length = this.heap.length;
+        const element = this.heap[n];
+        while (true) {
+            let leftN = 2 * n + 1;
+            let rightN = 2 * n + 2;
+            let swap = null;
+
+            if (leftN < length) {
+                const left = this.heap[leftN];
+                if (this.compare(left, element) < 0) swap = leftN;
+            }
+            if (rightN < length) {
+                const right = this.heap[rightN];
+                if ((swap === null && this.compare(right, element) < 0) ||
+                    (swap !== null && this.compare(right, this.heap[swap]) < 0)) {
+                    swap = rightN;
+                }
+            }
+            if (swap === null) break;
+            this.heap[n] = this.heap[swap];
+            this.heap[swap] = element;
+            n = swap;
+        }
+    }
+}

--- a/packages/core/pathfinding.js
+++ b/packages/core/pathfinding.js
@@ -1,18 +1,20 @@
 // packages/core/pathfinding.js
 // Accept map size so A* works on any grid dimension.
 
+import { MinHeap } from './minheap.js';
+
 export function astar(start, end, isBlocked, cols, rows) {
     const key = (x, y) => `${x},${y}`;
     const inBounds = (x, y) => x >= 0 && y >= 0 && x < cols && y < rows;
 
-    const open = [{ x: start.x, y: start.y, g: 0, h: 0, f: 0, from: null }];
+    const open = new MinHeap((a, b) => a.f - b.f);
+    open.push({ x: start.x, y: start.y, g: 0, h: 0, f: 0, from: null });
     const best = new Map(); best.set(key(start.x, start.y), 0);
     const H = (x, y) => Math.abs(x - end.x) + Math.abs(y - end.y);
     const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]];
 
-    while (open.length) {
-        let idx = 0; for (let i = 1; i < open.length; i++) if (open[i].f < open[idx].f) idx = i;
-        const cur = open.splice(idx, 1)[0];
+    while (open.size()) {
+        const cur = open.pop();
         if (cur.x === end.x && cur.y === end.y) {
             const path = []; let n = cur; while (n) { path.push({ x: n.x, y: n.y }); n = n.from; }
             path.reverse(); return path;

--- a/packages/core/pathfinding.test.js
+++ b/packages/core/pathfinding.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { astar } from './pathfinding.js';
+
+function runTest(cols, rows) {
+    const isBlocked = () => false;
+    const path = astar({ x: 0, y: 0 }, { x: cols - 1, y: rows - 1 }, isBlocked, cols, rows);
+    assert.ok(path, 'path should exist');
+    const expectedLength = cols + rows - 1;
+    assert.strictEqual(path.length, expectedLength);
+}
+
+function runObstacleTest() {
+    const blocked = new Set(['1,1']);
+    const isBlocked = (x, y) => blocked.has(`${x},${y}`);
+    const path = astar({ x: 0, y: 0 }, { x: 2, y: 2 }, isBlocked, 3, 3);
+    assert.ok(path, 'path should exist around obstacle');
+    assert.ok(!path.some(p => p.x === 1 && p.y === 1));
+    assert.strictEqual(path.length, 5);
+}
+
+runTest(5, 5);
+runTest(20, 20);
+runTest(50, 50);
+runObstacleTest();
+
+console.log('pathfinding tests passed');


### PR DESCRIPTION
## Summary
- replace linear scan in pathfinding A* with a binary min-heap
- add reusable MinHeap utility
- cover multiple grid sizes and obstacle scenarios in tests

## Testing
- `node packages/core/pathfinding.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a950554e048330b8d64e14356a65cc