### PR TITLE
refactor bfs queue to avoid shift

### DIFF
--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -80,10 +80,11 @@ export function createEngine(seedState) {
             const { cols, rows } = state.map.size;
             const visited = Array.from({ length: rows }, () => Array(cols).fill(false));
             const q = [{ x: start.x, y: start.y }];
+            let head = 0;
             visited[start.y][start.x] = true;
             const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
-            while (q.length) {
-                const cur = q.shift();
+            while (head < q.length) {
+                const cur = q[head++];
                 if (cur.x === end.x && cur.y === end.y) return true;
                 for (const [dx, dy] of dirs) {
                     const nx = cur.x + dx, ny = cur.y + dy;


### PR DESCRIPTION
## Summary
- replace queue shift with head pointer for BFS tile placement

## Testing
- `node packages/core/pathfinding.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a95651636c8330a6c9afb7a72e00b5