### PR TITLE
Fix wave and lives counters

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -86,7 +86,7 @@ export function advanceCreep(state, c, onLeak) {
 
   const speed = c.speed * slowMul;
   let A = c.path[c.seg], B = c.path[c.seg + 1];
-  if (!B) { c.alive = false; state.lives--; onLeak(); return; }
+  if (!B) { c.alive = false; onLeak(); return; }
 
   if (c._seg !== c.seg) {
     const vx = B.x - A.x, vy = B.y - A.y;

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -293,16 +293,8 @@ export function createEngine(seedState) {
 
 
     function startWave() {
-        state.wave += 1;
-        onWaveStart();
         return waves.startWave();
     }
-
-    function _waveStartInternal() {
-        state.wave++;
-        onWaveStart();
-    }
-    engine._waveStartInternal = _waveStartInternal;
 
     function loadMap(mapConfig) {
         validateMap(mapConfig);


### PR DESCRIPTION
## Summary
- Stop double incrementing wave count by delegating to wave controller
- Prevent double lives deduction when a creep leaks

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9587c3a988330acd6d6dc09ee8fe8