### PR TITLE
fix creep path after path recomputation

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -19,6 +19,8 @@ export function recomputePathingForAll(state, isBlocked) {
     if (npcCells) {
       c.path = npcCells.map(n => cellCenterForMap(state.map, n.x, n.y));
       c.seg = 0; c.t = 0;
+      c.x = c.path[0].x; c.y = c.path[0].y;
+      c._seg = -1;
     }
   }
 }


### PR DESCRIPTION
## Summary
- reset creep position and direction after recomputing path so they stay aligned

## Testing
- `npm test` *(fails: Missing script "test")*
- `node packages/core/pathfinding.test.js`
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_68a95f3d56708330884df8d8c062e1b7