### PR TITLE
Fix creep path recalculation to begin at current position

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -17,9 +17,10 @@ export function recomputePathingForAll(state, isBlocked) {
     const startCell = toCell(state, c.x, c.y);
     const npcCells = reconstructPath({ x: startCell.gx, y: startCell.gy }, dist, prev, size);
     if (npcCells) {
-      c.path = npcCells.map(n => cellCenterForMap(state.map, n.x, n.y));
+      const path = npcCells.map(n => cellCenterForMap(state.map, n.x, n.y));
+      path[0] = { x: c.x, y: c.y };
+      c.path = path;
       c.seg = 0; c.t = 0;
-      c.x = c.path[0].x; c.y = c.path[0].y;
       c._seg = -1;
     }
   }


### PR DESCRIPTION
## Summary
- Rebuild creep paths using cell centers and start them from the creep's current position
- Reset movement segment tracking to recompute direction without teleporting

## Testing
- `node packages/core/pathfinding.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a960e2ff4c8330873acbba8280156c