### PR TITLE
Limit particle pool and clear on reset

### DIFF
--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -6,7 +6,7 @@ import { defaultWaveConfig, createWaveController } from './waves.js';
 import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
 import { fireTower } from './towers.js';
 import { updateBullets } from './bullets.js';
-import { updateParticles } from './particles.js';
+import { updateParticles, clearParticlePool } from './particles.js';
 import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
 import { attachStats } from './stats.js';
@@ -464,6 +464,7 @@ export function createEngine(seedState) {
     function reset(seed) {
         waves.resetSpawner();
         resetState(state, { autoWaveEnabled: state.autoWaveEnabled, autoWaveDelay: state.autoWaveDelay, seed: state.seed, ...seed });
+        clearParticlePool();
         rebuildTowerGrid();
         recomputePathingForAll(state, isBlocked);
         neighborsSynergy();

--- a/packages/core/particles.js
+++ b/packages/core/particles.js
@@ -2,6 +2,7 @@
 // Simple particle updater for bullet impact effects
 
 const pool = [];
+const MAX_POOL = 10000;
 
 export function acquireParticle() {
     return pool.pop() || {};
@@ -9,7 +10,11 @@ export function acquireParticle() {
 
 export function releaseParticle(p) {
     for (const k in p) delete p[k];
-    pool.push(p);
+    if (pool.length < MAX_POOL) pool.push(p);
+}
+
+export function clearParticlePool() {
+    pool.length = 0;
 }
 
 export function updateParticles(state) {


### PR DESCRIPTION
## Summary
- Cap particle pool size to avoid unbounded growth and provide function to clear the pool
- Reset now drops pooled particles when game restarts

## Testing
- `node --check packages/core/particles.js && node --check packages/core/engine.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68abbcbb1a20833081f2e59e6bd98af1