### PR TITLE
Skip creep path updates when paths unchanged

### DIFF
--- a/packages/core/creeps.js
+++ b/packages/core/creeps.js
@@ -8,10 +8,20 @@ import { getDeathFx } from './deaths/index.js';
 export function recomputePathingForAll(state, isBlocked) {
   const { start, end, size } = state.map;
   const { dist, prev } = buildPredecessorGrid(end, isBlocked, size.cols, size.rows);
+  const mainPathCells = reconstructPath(start, dist, prev, size);
+  const newPath = mainPathCells ? mainPathCells.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+
+  // always update pathGrid
   state.pathGrid = { dist, prev };
 
-  const mainPathCells = reconstructPath(start, dist, prev, size);
-  state.path = mainPathCells ? mainPathCells.map(n => cellCenterForMap(state.map, n.x, n.y)) : [];
+  const oldPath = state.path || [];
+  const same =
+    oldPath.length === newPath.length &&
+    oldPath.every((p, i) => p.x === newPath[i].x && p.y === newPath[i].y);
+
+  if (same) return;
+
+  state.path = newPath;
 
   for (const c of state.creeps) {
     const startCell = toCell(state, c.x, c.y);


### PR DESCRIPTION
## Summary
- Recompute main path without mutating state until a new path is ready
- Skip per-creep path recalculation when the global path hasn't changed

## Testing
- `node packages/core/pathfinding.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abd5d577b483309132c8e5e47363ae