### PR TITLE
feat: apply neon vaporwave theme

### DIFF
--- a/docs/ADDING_ELEMENTS.md
+++ b/docs/ADDING_ELEMENTS.md
@@ -9,13 +9,13 @@ Each element lives in `packages/core/elements.js` and includes a `color` used fo
 ```js
 // packages/core/elements.js
 export const elements = {
-  FIRE:  { color:"#ef4444", status:"BURN" },
-  ICE:   { color:"#38bdf8", status:"CHILL" },
-  LIGHT: { color:"#a78bfa", status:"SHOCK" },
-  POISON:{ color:"#22c55e", status:"POISON" },
-  EARTH: { color:"#a3a3a3", status:"BRITTLE" },
-  WIND:  { color:"#60a5fa", status:"EXPOSED" },
-  // ARCANE: { color:"#be123c", status:"MANA_BURN" }, // example addition
+  FIRE:  { color:"#ff0066", status:"BURN" },
+  ICE:   { color:"#00eaff", status:"CHILL" },
+  LIGHT: { color:"#f8ff00", status:"SHOCK" },
+  POISON:{ color:"#39ff14", status:"POISON" },
+  EARTH: { color:"#ffb347", status:"BRITTLE" },
+  WIND:  { color:"#00bbff", status:"EXPOSED" },
+  // ARCANE: { color:"#bf00ff", status:"MANA_BURN" }, // example addition
 };
 ```
 

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -7,15 +7,15 @@
   <title>TD Engine — Vanilla Example</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="icon"
-    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='28' fill='%238b5cf6'/%3E%3Ccircle cx='24' cy='28' r='6' fill='%23ef4444'/%3E%3Ccircle cx='42' cy='38' r='6' fill='%2338bdf8'/%3E%3C/svg%3E" />
+    href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='28' fill='%23bf00ff'/%3E%3Ccircle cx='24' cy='28' r='6' fill='%23ff0066'/%3E%3Ccircle cx='42' cy='38' r='6' fill='%2300eaff'/%3E%3C/svg%3E" />
   <style>
     :root {
       --toolbar-h: 88px;
     }
 
     body {
-      background: #0b1326;
-      color: #e6edf3;
+      background: #1b0033;
+      color: #ffe6ff;
       font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Noto Sans", Helvetica, Arial;
     }
 
@@ -40,8 +40,8 @@
     }
 
     canvas {
-      background: #0b1326;
-      border: 1px solid #1f2a44;
+      background: #1b0033;
+      border: 1px solid #ff00ff;
       border-radius: 12px;
       image-rendering: pixelated;
       width: 100%;
@@ -94,7 +94,7 @@
 
   <!-- Mobile bottom toolbar (single source of truth on mobile) -->
   <div
-    class="mobile-toolbar fixed md:hidden inset-x-0 bottom-0 pb-[env(safe-area-inset-bottom)] bg-[rgba(5,8,16,.9)] border-t border-slate-700/60 backdrop-blur"
+    class="mobile-toolbar fixed md:hidden inset-x-0 bottom-0 pb-[env(safe-area-inset-bottom)] bg-[rgba(16,0,32,.9)] border-t border-[rgba(255,0,255,0.6)] backdrop-blur"
     id="mToolbar" style="height:var(--toolbar-h)">
     <div class="max-w-[1200px] mx-auto h-full px-3 flex items-center justify-between gap-2">
       <div class="flex gap-2">
@@ -121,7 +121,7 @@
   <!-- Game Over Modal -->
   <div id="goModal" class="fixed inset-0 hidden items-center justify-center z-50">
     <div class="absolute inset-0 bg-black/70"></div>
-    <div class="relative bg-slate-900 border border-slate-700 rounded-2xl w-[min(92vw,560px)] p-4">
+    <div class="relative bg-[#1b0033] border border-[#ff00ff] rounded-2xl w-[min(92vw,560px)] p-4">
       <div class="flex items-center justify-between mb-2">
         <h2 class="text-lg font-semibold">Game Over</h2>
         <button id="goClose" class="px-2 py-1 text-xs border rounded">Close</button>
@@ -136,7 +136,7 @@
   <!-- Pause Overlay -->
   <div id="pauseOverlay" class="fixed inset-0 hidden items-center justify-center z-50">
     <div class="absolute inset-0 bg-black/60"></div>
-    <div class="relative bg-slate-900 border border-slate-700 rounded-2xl w-[min(92vw,480px)] p-4">
+    <div class="relative bg-[#1b0033] border border-[#ff00ff] rounded-2xl w-[min(92vw,480px)] p-4">
       <div class="flex items-center justify-between">
         <h2 class="text-lg font-semibold">Paused</h2>
         <button id="poClose" class="px-2 py-1 text-xs border rounded">Resume</button>

--- a/packages/core/bullets.js
+++ b/packages/core/bullets.js
@@ -23,13 +23,13 @@ function addParticle(state, props) {
 
 function spawnImpact(state, b) {
     const rng = state.rng;
-    const color = b.color || '#94a3b8';
+      const color = b.color || '#ff99ff';
     let count = 6, speed = 40, ttl = 0.4, ring = 12;
     switch (b.elt) {
         case 'FIRE': {
             count = 12; speed = 140; ttl = 0.5; ring = 22;
             // bright flash for fiery explosion
-            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
+              addParticle(state, { x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#ff0066', circle: true });
             break;
         }
         case 'ICE': {
@@ -37,10 +37,10 @@ function spawnImpact(state, b) {
             // icy spikes
             for (let n = 0; n < 4; n++) {
                 const ang = rng() * Math.PI * 2;
-                addParticle(state, { x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
-                addParticle(state, { x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+                  addParticle(state, { x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#ccfaff', spark: true });
+                  addParticle(state, { x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#ccfaff', spark: true });
             }
-            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+              addParticle(state, { x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#aafcff', circle: true });
             break;
         }
         case 'LIGHT': {
@@ -51,12 +51,12 @@ function spawnImpact(state, b) {
                 const sp = 160;
                 addParticle(state, {
                     x: b.x, y: b.y,
-                    vx: Math.cos(ang) * sp,
-                    vy: Math.sin(ang) * sp,
-                    ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#faf5ff', spark: true,
+                      vx: Math.cos(ang) * sp,
+                      vy: Math.sin(ang) * sp,
+                      ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#f8ff00', spark: true,
                 });
             }
-            addParticle(state, { x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
+              addParticle(state, { x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#f8ff00', circle: true });
             break;
         }
         case 'POISON':

--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -32,15 +32,15 @@ export const Status = {
 // Tower definitions used to derive helpers like EltColor, EltType and
 // EltStatus.  Non-elemental towers simply omit a status effect.
 export const ELEMENTS = [
-  { key: 'ARCHER', color: '#9ca3af', type: 'bolt' },
-  { key: 'SIEGE', color: '#f59e0b', type: 'siege' },
-  { key: 'FIRE', color: '#ef4444', type: 'splash', status: Status.BURN },
-  { key: 'ICE', color: '#38bdf8', type: 'bolt', status: Status.CHILL },
-  { key: 'LIGHT', color: '#a78bfa', type: 'chain', status: Status.SHOCK },
-  { key: 'POISON', color: '#22c55e', type: 'bolt', status: Status.POISON },
-  { key: 'EARTH', color: '#a3a3a3', type: 'splash', status: Status.BRITTLE },
-  { key: 'WIND', color: '#60a5fa', type: 'bolt', status: Status.EXPOSED },
-  { key: 'ARCANE', color: '#be123c', type: 'bolt', status: Status.MANA_BURN }
+  { key: 'ARCHER', color: '#ffdd00', type: 'bolt' },
+  { key: 'SIEGE', color: '#ff4d00', type: 'siege' },
+  { key: 'FIRE', color: '#ff0066', type: 'splash', status: Status.BURN },
+  { key: 'ICE', color: '#00eaff', type: 'bolt', status: Status.CHILL },
+  { key: 'LIGHT', color: '#f8ff00', type: 'chain', status: Status.SHOCK },
+  { key: 'POISON', color: '#39ff14', type: 'bolt', status: Status.POISON },
+  { key: 'EARTH', color: '#ffb347', type: 'splash', status: Status.BRITTLE },
+  { key: 'WIND', color: '#00bbff', type: 'bolt', status: Status.EXPOSED },
+  { key: 'ARCANE', color: '#bf00ff', type: 'bolt', status: Status.MANA_BURN }
 ];
 
 export const EltColor = Object.fromEntries(ELEMENTS.map(e => [e.key, e.color]));

--- a/packages/core/deaths/boss.js
+++ b/packages/core/deaths/boss.js
@@ -12,7 +12,7 @@ function die(state, c) {
             x: c.x, y: c.y,
             vx: Math.cos(ang) * sp,
             vy: Math.sin(ang) * sp,
-            ttl: 0.6, max: 0.6, a: 1, color: '#fbbf24',
+            ttl: 0.6, max: 0.6, a: 1, color: '#f8ff00',
         });
     }
 }

--- a/packages/core/deaths/default.js
+++ b/packages/core/deaths/default.js
@@ -3,7 +3,7 @@
 
 function die(state, c) {
     // simple fade out ring
-    state.particles.push({ x: c.x, y: c.y, r: 0, vr: 80, ttl: 0.4, max: 0.4, a: 1, color: '#94a3b8', circle: true });
+    state.particles.push({ x: c.x, y: c.y, r: 0, vr: 80, ttl: 0.4, max: 0.4, a: 1, color: '#ff99ff', circle: true });
 }
 
 export default { die };

--- a/packages/core/effects/default.js
+++ b/packages/core/effects/default.js
@@ -7,7 +7,7 @@ function trail(state, b) {
 
 function basicImpact(state, b, opts = {}) {
     const rng = state.rng;
-    const { count = 6, speed = 40, ttl = 0.4, ring = 12, color = b.color || '#94a3b8' } = opts;
+    const { count = 6, speed = 40, ttl = 0.4, ring = 12, color = b.color || '#ff99ff' } = opts;
     state.particles.push({ x: b.x, y: b.y, r: 0, vr: ring / ttl, ttl, max: ttl, a: 1, color, ring: true });
     for (let n = 0; n < count; n++) {
         const ang = rng() * Math.PI * 2;

--- a/packages/core/effects/earth.js
+++ b/packages/core/effects/earth.js
@@ -3,11 +3,11 @@ import base from './default.js';
 
 function trail(state, b) {
     // subtle dust trail
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#d4d4d4', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#ffd1a9', circle: true });
 }
 
 function impact(state, b) {
-    base.basicImpact(state, b, { color: b.color || '#a3a3a3' });
+    base.basicImpact(state, b, { color: b.color || '#ffb347' });
 }
 
 function aoe(state, b) {

--- a/packages/core/effects/fire.js
+++ b/packages/core/effects/fire.js
@@ -3,14 +3,14 @@ import base from './default.js';
 
 function trail(state, b) {
     // fiery embers trailing behind
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#fb923c', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#ff4d6d', circle: true });
 }
 
 function impact(state, b) {
     const rng = state.rng;
-    base.basicImpact(state, b, { count: 12, speed: 140, ttl: 0.5, ring: 22, color: b.color || '#f97316' });
+    base.basicImpact(state, b, { count: 12, speed: 140, ttl: 0.5, ring: 22, color: b.color || '#ff0066' });
     // bright flash for fiery explosion
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#f97316', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 120, ttl: 0.25, max: 0.25, a: 1, color: '#ff0066', circle: true });
 }
 
 function aoe(state, b) {

--- a/packages/core/effects/ice.js
+++ b/packages/core/effects/ice.js
@@ -3,19 +3,19 @@ import base from './default.js';
 
 function trail(state, b) {
     // cold mist trail
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.3, max: 0.3, a: 1, color: '#aafcff', circle: true });
 }
 
 function impact(state, b) {
     const rng = state.rng;
-    base.basicImpact(state, b, { count: 8, speed: 40, ttl: 0.7, ring: 16, color: b.color || '#38bdf8' });
+    base.basicImpact(state, b, { count: 8, speed: 40, ttl: 0.7, ring: 16, color: b.color || '#00eaff' });
     // icy spikes
     for (let n = 0; n < 4; n++) {
         const ang = rng() * Math.PI * 2;
-        state.particles.push({ x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
-        state.particles.push({ x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#e0f2fe', spark: true });
+        state.particles.push({ x: b.x, y: b.y, ang, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#ccfaff', spark: true });
+        state.particles.push({ x: b.x, y: b.y, ang: ang + Math.PI / 2, len: 8, ttl: 0.5, max: 0.5, a: 1, color: '#ccfaff', spark: true });
     }
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#bae6fd', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 60, ttl: 0.3, max: 0.3, a: 1, color: '#aafcff', circle: true });
 }
 
 function aoe(state, b) {

--- a/packages/core/effects/light.js
+++ b/packages/core/effects/light.js
@@ -5,13 +5,13 @@ function trail(state, b) {
     const rng = state.rng;
     if (rng() < 0.5) {
         const ang = rng() * Math.PI * 2;
-        state.particles.push({ x: b.x, y: b.y, ang, len: 6, ttl: 0.2, max: 0.2, a: 1, color: '#faf5ff', spark: true });
+        state.particles.push({ x: b.x, y: b.y, ang, len: 6, ttl: 0.2, max: 0.2, a: 1, color: '#f8ff00', spark: true });
     }
 }
 
 function impact(state, b) {
     const rng = state.rng;
-    base.basicImpact(state, b, { count: 12, speed: 180, ttl: 0.3, ring: 20, color: b.color || '#a78bfa' });
+    base.basicImpact(state, b, { count: 12, speed: 180, ttl: 0.3, ring: 20, color: b.color || '#f8ff00' });
     // electric sparks
     for (let n = 0; n < 6; n++) {
         const ang = rng() * Math.PI * 2;
@@ -20,10 +20,10 @@ function impact(state, b) {
             x: b.x, y: b.y,
             vx: Math.cos(ang) * sp,
             vy: Math.sin(ang) * sp,
-            ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#faf5ff', spark: true,
+            ang, len: 12, ttl: 0.3, max: 0.3, a: 1, color: '#f8ff00', spark: true,
         });
     }
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#faf5ff', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 200, ttl: 0.15, max: 0.15, a: 1, color: '#f8ff00', circle: true });
 }
 
 function aoe(state, b) {

--- a/packages/core/effects/poison.js
+++ b/packages/core/effects/poison.js
@@ -2,11 +2,11 @@
 import base from './default.js';
 
 function trail(state, b) {
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.25, max: 0.25, a: 1, color: '#4ade80', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.25, max: 0.25, a: 1, color: '#b5ff66', circle: true });
 }
 
 function impact(state, b) {
-    base.basicImpact(state, b, { count: 7, speed: 45, ttl: 0.6, ring: 16, color: b.color || '#22c55e' });
+    base.basicImpact(state, b, { count: 7, speed: 45, ttl: 0.6, ring: 16, color: b.color || '#39ff14' });
 }
 
 function aoe(state, b) {

--- a/packages/core/effects/wind.js
+++ b/packages/core/effects/wind.js
@@ -3,11 +3,11 @@ import base from './default.js';
 
 function trail(state, b) {
     // faint breeze trails
-    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#93c5fd', circle: true });
+    state.particles.push({ x: b.x, y: b.y, r: 0, vr: 0, ttl: 0.2, max: 0.2, a: 1, color: '#80d8ff', circle: true });
 }
 
 function impact(state, b) {
-    base.basicImpact(state, b, { color: b.color || '#60a5fa' });
+    base.basicImpact(state, b, { color: b.color || '#00bbff' });
 }
 
 function aoe(state, b) {

--- a/packages/render-canvas/index.js
+++ b/packages/render-canvas/index.js
@@ -18,7 +18,7 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     if (!opts.showGrid) return;
     const { cols, rows } = map.size;
     ctx.save();
-    ctx.strokeStyle = '#1f2937'; // slate-800
+      ctx.strokeStyle = 'rgba(255,0,255,0.2)'; // neon magenta grid
     ctx.lineWidth = 1;
     for (let x = 0; x <= cols; x++) {
       ctx.beginPath(); ctx.moveTo(x * TILE, 0); ctx.lineTo(x * TILE, rows * TILE); ctx.stroke();
@@ -33,8 +33,8 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     const p = state.path;
     if (!p || p.length < 2) return;
     const g = ctx.createLinearGradient(p[0].x, p[0].y, p[p.length - 1].x, p[p.length - 1].y);
-    g.addColorStop(0, '#64748b'); // slate-400
-    g.addColorStop(1, '#8b5cf6'); // violet-500
+      g.addColorStop(0, '#ff00ff'); // neon magenta
+      g.addColorStop(1, '#00ffff'); // neon cyan
     ctx.save();
     ctx.strokeStyle = g;
     ctx.lineWidth = 10;
@@ -50,11 +50,11 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
   function drawStartEnd(state) {
     const s = state.startPx, e = state.endPx;
     ctx.save();
-    // start (green)
-    ctx.fillStyle = '#10b981'; // emerald-500
+      // start (neon green)
+      ctx.fillStyle = '#39ff14';
     ctx.beginPath(); ctx.arc(s.x, s.y, 6, 0, Math.PI * 2); ctx.fill();
-    // end (gold)
-    ctx.fillStyle = '#f59e0b'; // amber-500
+      // end (neon yellow)
+      ctx.fillStyle = '#f8ff00';
     ctx.beginPath(); ctx.arc(e.x, e.y, 6, 0, Math.PI * 2); ctx.fill();
     ctx.restore();
   }
@@ -63,8 +63,8 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     if (!opts.showBlocked) return;
     if (!map.blocked || !map.blocked.length) return;
     ctx.save();
-    ctx.fillStyle = 'rgba(148,163,184,.28)'; // slate-400 @ ~28%
-    ctx.strokeStyle = 'rgba(148,163,184,.45)';
+      ctx.fillStyle = 'rgba(255,0,255,.28)'; // neon magenta @ ~28%
+      ctx.strokeStyle = 'rgba(255,0,255,.45)';
     for (const { x, y } of map.blocked) {
       const px = x * TILE, py = y * TILE;
       ctx.fillRect(px, py, TILE, TILE);
@@ -84,7 +84,7 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       const off = document.createElement('canvas');
       off.width = 8; off.height = 8;
       const c2 = off.getContext('2d');
-      c2.strokeStyle = 'rgba(220, 38, 38, .35)'; // red-600 @ 35%
+        c2.strokeStyle = 'rgba(0,255,255,.35)'; // neon cyan @ 35%
       c2.lineWidth = 1;
       c2.beginPath();
       c2.moveTo(0, 8); c2.lineTo(8, 0);
@@ -111,24 +111,24 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       ctx.translate(c.x, c.y);
 
       // body
-      ctx.fillStyle = '#e5e7eb'; // gray-200
+        ctx.fillStyle = '#ffe4ff'; // light neon pink
       ctx.beginPath(); ctx.arc(0, 0, 8, 0, Math.PI * 2); ctx.fill();
 
       // health bar
       const pct = Math.max(0, Math.min(1, c.hp / c.maxhp));
       const w = 18, h = 3;
-      ctx.fillStyle = '#0b1220'; ctx.fillRect(-w / 2, -12, w, h);
-      ctx.fillStyle = pct > 0.5 ? '#22c55e' : (pct > 0.2 ? '#f59e0b' : '#ef4444');
+        ctx.fillStyle = '#220033'; ctx.fillRect(-w / 2, -12, w, h);
+        ctx.fillStyle = pct > 0.5 ? '#39ff14' : (pct > 0.2 ? '#f8ff00' : '#ff073a');
       ctx.fillRect(-w / 2, -12, w * pct, h);
 
       // status pips (BURN/POISON/CHILL/SHOCK/stun)
       let dx = -9;
       function pip(color) { ctx.fillStyle = color; ctx.fillRect(dx, -18, 3, 3); dx += 4; }
-      if (c.status?.BURN) pip('#ef4444');
-      if (c.status?.POISON) pip('#22c55e');
-      if (c.status?.CHILL) pip('#38bdf8');
-      if (c.status?.SHOCK) pip('#a78bfa');
-      if (c.status?.stun && c.status.stun > 0) pip('#fbbf24');
+      if (c.status?.BURN) pip('#ff073a');
+      if (c.status?.POISON) pip('#39ff14');
+      if (c.status?.CHILL) pip('#00eaff');
+      if (c.status?.SHOCK) pip('#d580ff');
+      if (c.status?.stun && c.status.stun > 0) pip('#f8ff00');
 
       ctx.restore();
     }
@@ -140,8 +140,8 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       ctx.save();
       ctx.translate(t.x, t.y);
       const elt = t.elt || t.kind;
-      const extraColors = { ARCHER: '#fbbf24', CANNON: '#9ca3af', SIEGE: '#9ca3af' };
-      const color = EltColor[elt] || extraColors[elt] || '#94a3b8';
+        const extraColors = { ARCHER: '#ffdd00', CANNON: '#ff4d00', SIEGE: '#ff4d00' };
+        const color = EltColor[elt] || extraColors[elt] || '#ff99ff';
       ctx.fillStyle = color;
       ctx.shadowColor = color; ctx.shadowBlur = 16;
       ctx.beginPath(); ctx.arc(0, 0, 12, 0, Math.PI * 2); ctx.fill();
@@ -156,7 +156,7 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       }
 
       // tiny ticks for level
-      ctx.fillStyle = '#0b1020';
+        ctx.fillStyle = '#1a0033';
       for (let i = 0; i < t.lvl; i++) ctx.fillRect(-10 + i * 6, 10, 4, 3);
 
       ctx.restore();
@@ -167,8 +167,8 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     for (const b of state.bullets) {
       ctx.save();
       ctx.translate(b.x, b.y);
-      const extraColors = { ARCHER: '#fbbf24', CANNON: '#9ca3af', SIEGE: '#9ca3af' };
-      const color = b.color || EltColor[b.elt] || extraColors[b.elt] || '#94a3b8';
+        const extraColors = { ARCHER: '#ffdd00', CANNON: '#ff4d00', SIEGE: '#ff4d00' };
+        const color = b.color || EltColor[b.elt] || extraColors[b.elt] || '#ff99ff';
       ctx.fillStyle = color;
       ctx.shadowColor = color; ctx.shadowBlur = 12;
 
@@ -240,15 +240,15 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       ctx.save();
       if (p.ring) {
         ctx.globalAlpha = Math.max(0, p.a ?? 0.6);
-        ctx.strokeStyle = p.color || '#94a3b8';
+        ctx.strokeStyle = p.color || '#ff99ff';
         ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2); ctx.stroke();
       } else if (p.circle) {
         ctx.globalAlpha = Math.max(0, p.a ?? 0.6);
-        ctx.fillStyle = p.color || '#94a3b8';
+        ctx.fillStyle = p.color || '#ff99ff';
         ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, Math.PI * 2); ctx.fill();
       } else if (p.spark) {
         ctx.globalAlpha = Math.max(0, p.a ?? 1);
-        ctx.strokeStyle = p.color || '#94a3b8';
+        ctx.strokeStyle = p.color || '#ff99ff';
         ctx.lineWidth = 2;
         const len = p.len || 6;
         ctx.beginPath();
@@ -257,7 +257,7 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
         ctx.stroke();
       } else {
         ctx.globalAlpha = Math.max(0, p.a ?? 1);
-        ctx.fillStyle = p.color || '#94a3b8';
+        ctx.fillStyle = p.color || '#ff99ff';
         ctx.fillRect(p.x, p.y, 2, 2);
       }
       ctx.restore();
@@ -270,7 +270,7 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     const x = gx * TILE, y = gy * TILE;
     ctx.save();
     ctx.globalAlpha = 0.25;
-    ctx.fillStyle = valid ? '#22c55e' : '#ef4444';
+    ctx.fillStyle = valid ? '#39ff14' : '#ff073a';
     ctx.fillRect(x, y, TILE, TILE);
     ctx.restore();
   }


### PR DESCRIPTION
## Summary
- switch canvas rendering and particles to neon vaporwave colours
- update element palette and example HTML to match new theme
- document revised element colour map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68abd6f3ceb4833089d4b1d19a37ebeb