### PR TITLE
feat: add manga style renderer demo

### DIFF
--- a/examples/manga/app.js
+++ b/examples/manga/app.js
@@ -1,0 +1,27 @@
+import { createEngine } from '../../packages/core/engine.js';
+import { createCanvasRenderer } from '../../packages/render-canvas/index.js';
+import { TILE } from '../../packages/core/content.js';
+import { twistMap } from '../../maps/twist-24x16.js';
+
+const engine = createEngine();
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d', { alpha: false });
+const renderer = createCanvasRenderer({ ctx, engine, options: { theme: 'manga' } });
+
+function resize() {
+  const { cols, rows } = engine.state.map.size;
+  canvas.width = cols * TILE;
+  canvas.height = rows * TILE;
+}
+
+function loop(now) {
+  requestAnimationFrame(loop);
+  const dt = 1 / 60;
+  engine.step(dt);
+  renderer.render(engine.state, dt);
+}
+
+engine.loadMap(twistMap);
+engine.reset();
+resize();
+requestAnimationFrame(loop);

--- a/examples/manga/index.html
+++ b/examples/manga/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Manga Style Demo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet">
+  <style>
+    body {
+      background-color: #f4f5f7;
+      background-image: radial-gradient(#0002 1px, transparent 1px);
+      background-size: 8px 8px;
+      font-family: 'Bangers', cursive;
+      color: #0b1326;
+    }
+    canvas {
+      background: #fff;
+      border: 4px solid #0b1326;
+      border-radius: 4px;
+      image-rendering: pixelated;
+    }
+  </style>
+</head>
+<body class="flex items-center justify-center min-h-screen">
+  <canvas id="game" width="768" height="512"></canvas>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add optional manga theme to canvas renderer with halftone background and motion lines
- include demo example showing manga style styling

## Testing
- `node packages/core/pathfinding.test.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abd7008700833080685dd4e9752c12