### PR TITLE
Add steampunk theme to vanilla example

### DIFF
--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -49,6 +49,7 @@
       touch-action: none;
     }
   </style>
+  <link rel="stylesheet" href="./steampunk.css" />
 </head>
 
 <body class="p-4 md:p-6">

--- a/examples/vanilla/steampunk.css
+++ b/examples/vanilla/steampunk.css
@@ -1,0 +1,48 @@
+@import url('https://fonts.googleapis.com/css2?family=IM+Fell+English+SC&family=Roboto&display=swap');
+
+:root {
+  --metal-dark: #2b2b2b;
+  --metal-medium: #8c6239;
+  --metal-light: #b68d40;
+  --paper: #f8f5e1;
+}
+
+body {
+  background-color: #1d1a15;
+  background-image: radial-gradient(rgba(255,255,255,0.05) 1px, transparent 0);
+  background-size: 8px 8px;
+  color: var(--paper);
+  font-family: 'Roboto', system-ui, sans-serif;
+}
+
+h1, h2, h3, h4, h5 {
+  font-family: 'IM Fell English SC', serif;
+  color: var(--metal-light);
+}
+
+button {
+  background: linear-gradient(var(--metal-light), var(--metal-medium));
+  border: 2px solid #4d2c1e;
+  color: #fdf5e6;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  transition: filter 0.2s ease;
+}
+
+button:hover {
+  filter: brightness(1.1);
+}
+
+.mobile-toolbar,
+aside,
+#pauseOverlay > div,
+#goModal > div {
+  background: var(--metal-dark);
+  border: 1px solid #4d2c1e;
+}
+
+canvas {
+  background: #13110e;
+  border: 2px solid #4d2c1e;
+}


### PR DESCRIPTION
## Summary
- introduce steampunk-inspired stylesheet with brass palette, vintage fonts, and button textures
- link the new stylesheet into the vanilla example

## Testing
- `node packages/core/pathfinding.test.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68abd707f020833084f0b3afc3e54119