### PR TITLE
feat: add sprite support for towers and creeps

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -14,7 +14,14 @@ const { fit } = attachViewportFit(canvas, {
   headerSelector: 'header' // update to your actual header class/selector if you have one
 });
 const ctx = canvas.getContext('2d', { alpha: false });
-const renderer = createCanvasRenderer({ ctx, engine });
+const renderer = createCanvasRenderer({
+  ctx,
+  engine,
+  sprites: {
+    creeps: { default: 'sprites/creep.svg' },
+    towers: { default: 'sprites/tower.svg' },
+  },
+});
 
 
 // ---------- Input helpers ----------

--- a/examples/vanilla/sprites/creep.svg
+++ b/examples/vanilla/sprites/creep.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <circle cx="16" cy="16" r="14" fill="#e5e7eb" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/tower.svg
+++ b/examples/vanilla/sprites/tower.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <rect x="4" y="4" width="24" height="24" fill="#94a3b8" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/packages/render-canvas/index.js
+++ b/packages/render-canvas/index.js
@@ -4,13 +4,37 @@
 
 import { TILE, EltColor } from '../core/content.js';
 
-export function createCanvasRenderer({ ctx, engine, options = {} }) {
+export function createCanvasRenderer({ ctx, engine, options = {}, sprites = {} }) {
   const opts = {
     showGrid: true,
     showBlocked: true,
     showBuildMask: true,
     ...options,
   };
+
+  // sprite loading
+  const creepSprites = {};
+  const towerSprites = {};
+
+  function loadImage(src) {
+    const img = new Image();
+    img.src = src;
+    return img;
+  }
+
+  if (sprites.creeps) {
+    for (const [key, src] of Object.entries(sprites.creeps)) {
+      creepSprites[key] = loadImage(src);
+    }
+  }
+  if (sprites.towers) {
+    for (const [key, src] of Object.entries(sprites.towers)) {
+      towerSprites[key] = loadImage(src);
+    }
+  }
+
+  const getCreepSprite = type => creepSprites[type] || creepSprites.default;
+  const getTowerSprite = elt => towerSprites[elt] || towerSprites.default;
 
   // --- helpers -------------------------------------------------------------
 
@@ -109,10 +133,14 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
     for (const c of state.creeps) {
       ctx.save();
       ctx.translate(c.x, c.y);
-
-      // body
-      ctx.fillStyle = '#e5e7eb'; // gray-200
-      ctx.beginPath(); ctx.arc(0, 0, 8, 0, Math.PI * 2); ctx.fill();
+      const img = getCreepSprite(c.type);
+      if (img && img.complete) {
+        ctx.drawImage(img, -8, -8, 16, 16);
+      } else {
+        // body fallback
+        ctx.fillStyle = '#e5e7eb'; // gray-200
+        ctx.beginPath(); ctx.arc(0, 0, 8, 0, Math.PI * 2); ctx.fill();
+      }
 
       // health bar
       const pct = Math.max(0, Math.min(1, c.hp / c.maxhp));
@@ -142,10 +170,15 @@ export function createCanvasRenderer({ ctx, engine, options = {} }) {
       const elt = t.elt || t.kind;
       const extraColors = { ARCHER: '#fbbf24', CANNON: '#9ca3af', SIEGE: '#9ca3af' };
       const color = EltColor[elt] || extraColors[elt] || '#94a3b8';
-      ctx.fillStyle = color;
-      ctx.shadowColor = color; ctx.shadowBlur = 16;
-      ctx.beginPath(); ctx.arc(0, 0, 12, 0, Math.PI * 2); ctx.fill();
-      ctx.shadowBlur = 0;
+      const img = getTowerSprite(elt);
+      if (img && img.complete) {
+        ctx.drawImage(img, -12, -12, 24, 24);
+      } else {
+        ctx.fillStyle = color;
+        ctx.shadowColor = color; ctx.shadowBlur = 16;
+        ctx.beginPath(); ctx.arc(0, 0, 12, 0, Math.PI * 2); ctx.fill();
+        ctx.shadowBlur = 0;
+      }
 
       // range ring if selected
       if (state.selectedTowerId === t.id) {


### PR DESCRIPTION
## Summary
- add sprite image support in canvas renderer
- pass placeholder tower and creep sprites in vanilla example
- include sample SVG sprites for towers and creeps

## Testing
- `node packages/core/pathfinding.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abdc6787b0833087808798ee6d77c1