### PR TITLE
Add Vitest tests for core engine modules

### DIFF
--- a/packages/core/bullets.test.js
+++ b/packages/core/bullets.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { updateBullets } from './bullets.js';
+import { rebuildCreepGrid } from './spatial.js';
+import { getEffect } from './effects/index.js';
+import { makeRng } from './rng.js';
+
+describe('bullets', () => {
+  it('apply damage on impact', () => {
+    const creep = { id: 'c', x: 0, y: 0, alive: true, hp: 10, status: {}, resist: {}, gold: 0 };
+    const state = {
+      rng: makeRng(1),
+      dt: 0.1,
+      creeps: [creep],
+      creepGrid: new Map(),
+      creepCellSize: 40,
+      bullets: [{
+        kind: 'splash', x: 0, y: 0, vx: 0, vy: 0, ttl: 0,
+        aoe: 20, dmg: 5, elt: 'FIRE', status: null, mod: {}, fromId: 't1', effect: getEffect('FIRE')
+      }],
+      particles: [],
+      hits: 0
+    };
+    rebuildCreepGrid(state);
+    updateBullets(state, { onCreepDamage: () => {} });
+    expect(creep.hp).toBeLessThan(10);
+    expect(state.bullets.length).toBe(0);
+  });
+});

--- a/packages/core/combos.test.js
+++ b/packages/core/combos.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { applyStatus } from './combat.js';
+import { Status } from './content.js';
+
+describe('combos', () => {
+  it('triggers acid burn combo from burn and poison', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.BURN);
+    const result = applyStatus(creep, Status.POISON);
+    expect(result).toBe('combo.acid');
+  });
+});

--- a/packages/core/config.test.js
+++ b/packages/core/config.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { resolveConfig } from './config.js';
+
+describe('config', () => {
+  it('falls back to default renderer', () => {
+    const cfg = resolveConfig({ renderer: 'invalid' });
+    expect(cfg.renderer).toBe('webgpu');
+  });
+});

--- a/packages/core/creeps.test.js
+++ b/packages/core/creeps.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
+import { createDefaultMap, cellCenterForMap } from './map.js';
+
+describe('creeps', () => {
+  it('advances along path and can be culled when dead', () => {
+    const map = createDefaultMap();
+    const state = { map, creeps: [], dt: 0.1, path: [], pathGrid: null, gold: 0, score: 0 };
+    recomputePathingForAll(state, () => false);
+    const startPx = cellCenterForMap(map, map.start.x, map.start.y);
+    const endPx = cellCenterForMap(map, map.end.x, map.end.y);
+    const creep = {
+      id: 'c', type: 'Grunt', x: startPx.x, y: startPx.y, seg: 0, t: 0,
+      path: [startPx, endPx], speed: 100, status: {}, hp: 5, maxhp: 5,
+      resist: {}, gold: 1, alive: true
+    };
+    state.creeps.push(creep);
+    advanceCreep(state, creep, () => { state.leaked = true; });
+    expect(creep.x).not.toBe(startPx.x);
+    creep.hp = 0;
+    cullDead(state, {});
+    expect(state.creeps.length).toBe(0);
+  });
+});

--- a/packages/core/effects.test.js
+++ b/packages/core/effects.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getEffect } from './effects/index.js';
+
+describe('effects', () => {
+  it('returns effect object with trail and impact', () => {
+    const eff = getEffect('FIRE');
+    expect(typeof eff.trail).toBe('function');
+    expect(typeof eff.impact).toBe('function');
+  });
+});

--- a/packages/core/engine.test.js
+++ b/packages/core/engine.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine, Elt } from './engine.js';
+import { createDefaultMap, cellCenterForMap } from './map.js';
+
+describe('engine', () => {
+  function spawnSimpleCreep(engine) {
+    const base = engine.state.creepProfiles.Grunt;
+    const start = engine.state.map.start;
+    const end = engine.state.map.end;
+    const startPx = cellCenterForMap(engine.state.map, start.x, start.y);
+    const endPx = cellCenterForMap(engine.state.map, end.x, end.y);
+    const creep = {
+      id: 'c1',
+      type: 'Grunt',
+      x: startPx.x,
+      y: startPx.y,
+      seg: 0,
+      t: 0,
+      hp: base.hp,
+      maxhp: base.hp,
+      speed: base.speed,
+      resist: { ...base.resist },
+      gold: base.gold,
+      status: {},
+      alive: true,
+      path: [startPx, endPx]
+    };
+    engine.state.creeps.push(creep);
+    return creep;
+  }
+
+  it('allows tower placement and damages creeps', () => {
+    const map = createDefaultMap();
+    const engine = createEngine({ map });
+    const { start } = engine.state.map;
+    const res = engine.placeTower(start.x + 1, start.y, Elt.ARCHER);
+    expect(res.ok).toBe(true);
+    const creep = spawnSimpleCreep(engine);
+    for (let i = 0; i < 200; i++) {
+      engine.step(0.05);
+    }
+    expect(creep.hp).toBeLessThan(creep.maxhp);
+  });
+
+  it('reduces lives when creeps leak', () => {
+    const map = createDefaultMap();
+    const engine = createEngine({ map });
+    spawnSimpleCreep(engine);
+    for (let i = 0; i < 400; i++) {
+      engine.step(0.05);
+    }
+    expect(engine.state.lives).toBeLessThan(20);
+  });
+});

--- a/packages/core/loot.test.js
+++ b/packages/core/loot.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { lootTables, weightedPick } from './loot.js';
+import { makeRng } from './rng.js';
+
+describe('loot', () => {
+  it('picks entries deterministically', () => {
+    const rngA = makeRng(1);
+    const rngB = makeRng(1);
+    const pickA = weightedPick(lootTables.common, rngA);
+    const pickB = weightedPick(lootTables.common, rngB);
+    expect(pickA.id).toBe(pickB.id);
+  });
+});

--- a/packages/core/map.test.js
+++ b/packages/core/map.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { validateMap, makeBuildableChecker, createDefaultMap } from './map.js';
+
+describe('map utilities', () => {
+  it('validates default map', () => {
+    const map = createDefaultMap();
+    expect(validateMap(map)).toBe(true);
+  });
+
+  it('detects buildable cells', () => {
+    const map = createDefaultMap();
+    const canBuild = makeBuildableChecker(map);
+    expect(canBuild(1, 1)).toBe(true);
+    expect(canBuild(map.start.x, map.start.y)).toBe(false);
+  });
+});

--- a/packages/core/pathfinding.test.js
+++ b/packages/core/pathfinding.test.js
@@ -1,26 +1,31 @@
-import assert from 'node:assert';
+import { describe, it, expect } from 'vitest';
 import { astar } from './pathfinding.js';
 
-function runTest(cols, rows) {
+describe('pathfinding', () => {
+  function runTest(cols, rows) {
     const isBlocked = () => false;
     const path = astar({ x: 0, y: 0 }, { x: cols - 1, y: rows - 1 }, isBlocked, cols, rows);
-    assert.ok(path, 'path should exist');
+    expect(path).toBeTruthy();
     const expectedLength = cols + rows - 1;
-    assert.strictEqual(path.length, expectedLength);
-}
+    expect(path.length).toBe(expectedLength);
+  }
 
-function runObstacleTest() {
+  function runObstacleTest() {
     const blocked = new Set(['1,1']);
     const isBlocked = (x, y) => blocked.has(`${x},${y}`);
     const path = astar({ x: 0, y: 0 }, { x: 2, y: 2 }, isBlocked, 3, 3);
-    assert.ok(path, 'path should exist around obstacle');
-    assert.ok(!path.some(p => p.x === 1 && p.y === 1));
-    assert.strictEqual(path.length, 5);
-}
+    expect(path).toBeTruthy();
+    expect(path.some(p => p.x === 1 && p.y === 1)).toBe(false);
+    expect(path.length).toBe(5);
+  }
 
-runTest(5, 5);
-runTest(20, 20);
-runTest(50, 50);
-runObstacleTest();
+  it('finds path on various grid sizes', () => {
+    runTest(5, 5);
+    runTest(20, 20);
+    runTest(50, 50);
+  });
 
-console.log('pathfinding tests passed');
+  it('navigates around obstacles', () => {
+    runObstacleTest();
+  });
+});

--- a/packages/core/progression.test.js
+++ b/packages/core/progression.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { hpMulAtWave, speedMulAtWave, goldForKill, composeWave } from './progression.js';
+
+describe('progression', () => {
+  it('scales hp and speed with wave', () => {
+    expect(hpMulAtWave(5)).toBeGreaterThan(hpMulAtWave(1));
+    expect(speedMulAtWave(10)).toBeGreaterThan(speedMulAtWave(1));
+  });
+
+  it('computes gold for kill and composes waves', () => {
+    expect(goldForKill('Grunt', 5, 1)).toBeGreaterThan(1);
+    const packs = composeWave(1);
+    expect(Array.isArray(packs)).toBe(true);
+    expect(packs.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/rng.test.js
+++ b/packages/core/rng.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { makeRng } from './rng.js';
+
+describe('rng', () => {
+  it('produces deterministic sequences for same seed', () => {
+    const a = makeRng(123);
+    const b = makeRng(123);
+    const seqA = [a(), a(), a()];
+    const seqB = [b(), b(), b()];
+    expect(seqA).toEqual(seqB);
+  });
+});

--- a/packages/core/selectors.test.js
+++ b/packages/core/selectors.test.js
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { buildHudSnapshot } from './selectors.js';
+import { Elt } from './content.js';
+
+describe('selectors', () => {
+  it('builds HUD snapshot', () => {
+    const state = { gold: 100, lives: 20, wave: 1, spree: 0, score: 0, hits: 0, shots: 0, speed: 1, buildSel: Elt.FIRE };
+    const hud = buildHudSnapshot(state);
+    expect(hud.gold).toBe(100);
+    expect(hud.canAfford(Elt.FIRE)).toBe(true);
+  });
+});

--- a/packages/core/state.test.js
+++ b/packages/core/state.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { createInitialState } from './state.js';
+
+describe('state', () => {
+  it('creates initial state with defaults', () => {
+    const state = createInitialState();
+    expect(state.gold).toBe(250);
+    expect(state.towers).toEqual([]);
+  });
+});

--- a/packages/core/stats.test.js
+++ b/packages/core/stats.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { attachStats } from './stats.js';
+
+describe('stats', () => {
+  it('tracks kills via hooks', () => {
+    const handlers = {};
+    const engine = {
+      hook(name, fn) {
+        (handlers[name] ||= []).push(fn);
+        return () => {};
+      }
+    };
+    const stats = attachStats(engine);
+    // simulate a kill
+    handlers.creepKill[0]({ type: 'Grunt', gold: 1 });
+    const summary = stats.summary();
+    expect(summary.totals.creepsKilled).toBe(1);
+  });
+});

--- a/packages/core/towers.test.js
+++ b/packages/core/towers.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { targetInRange } from './towers.js';
+import { rebuildCreepGrid } from './spatial.js';
+
+describe('towers targeting', () => {
+  it('selects closest creep based on targeting mode', () => {
+    const state = { creeps: [], creepGrid: new Map(), creepCellSize: 40 };
+    const creepA = { id: 'a', x: 50, y: 0, alive: true, seg: 0, t: 0 };
+    const creepB = { id: 'b', x: 150, y: 0, alive: true, seg: 0, t: 0 };
+    state.creeps.push(creepA, creepB);
+    rebuildCreepGrid(state);
+    const tower = { x: 0, y: 0, range: 200, targeting: 'first' };
+    const target = targetInRange(state, tower);
+    expect(target.id).toBe('b'); // 'first' picks farthest progress
+    tower.targeting = 'last';
+    const last = targetInRange(state, tower);
+    expect(last.id).toBe('a');
+  });
+});

--- a/packages/core/upgrades.test.js
+++ b/packages/core/upgrades.test.js
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { upgradePools } from './upgrades.js';
+
+describe('upgrades', () => {
+  it('applies upgrade effects', () => {
+    const tower = { range: 100, firerate: 1, dmg: 10, mod: {} };
+    const upg = upgradePools.any[0];
+    upg.apply(tower);
+    expect(tower.range).toBeGreaterThan(100);
+  });
+});

--- a/packages/core/waves.test.js
+++ b/packages/core/waves.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { createWaveController, defaultWaveConfig } from './waves.js';
+
+describe('waves', () => {
+  it('spawns creeps when stepping spawner', () => {
+    const state = { wave: 0, creeps: [], gold: 0 };
+    let spawned = 0;
+    const ctrl = createWaveController(state, {
+      getWavePacks: defaultWaveConfig,
+      spawnCreep: () => { spawned++; },
+      onWaveStart: () => {},
+      onWaveEnd: () => {},
+      awardWaveGold: () => {}
+    });
+    expect(ctrl.startWave()).toBe(true);
+    for (let i = 0; i < 20; i++) ctrl.stepSpawner(1);
+    expect(spawned).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest test suites for core modules including engine, towers, creeps, bullets, waves, map utilities, progression, upgrades, loot, combos, stats, RNG, config, state, selectors, effects, and pathfinding
- port existing pathfinding test to Vitest

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68abe2131980833096ff05f154ddb73e