### PR TITLE
test: add canvas and WebGPU renderer tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
     "statements": 80
   },
   "devDependencies": {
-    "@vitest/coverage-c8": "latest",
-    "happy-dom": "^14.5.1",
-    "vitest": "0.33",
-    "happy-dom": "^10.0.0"
+    "@vitest/coverage-v8": "^3.2.4",
+    "happy-dom": "latest",
+    "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,22 +1,25 @@
 {
-    "name": "@your-scope/td-core",
-    "type": "module",
-    "exports": {
-        ".": {
-            "types": "./index.d.ts",
-            "default": "./index.js"
-        },
-        "./engine.js": {
-            "types": "./engine.d.ts",
-            "default": "./engine.js"
-        },
-        "./content.js": {
-            "types": "./content.d.ts",
-            "default": "./content.js"
-        },
-        "./selectors.js": {
-            "types": "./selectors.d.ts",
-            "default": "./selectors.js"
-        }
+  "name": "@your-scope/td-core",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./engine.js": {
+      "types": "./engine.d.ts",
+      "default": "./engine.js"
+    },
+    "./content.js": {
+      "types": "./content.d.ts",
+      "default": "./content.js"
+    },
+    "./selectors.js": {
+      "types": "./selectors.d.ts",
+      "default": "./selectors.js"
     }
+  },
+  "devDependencies": {
+    "happy-dom": "^10.0.0"
+  }
 }

--- a/packages/render-canvas/index.test.js
+++ b/packages/render-canvas/index.test.js
@@ -1,0 +1,90 @@
+import assert from 'node:assert';
+import { Window } from 'happy-dom';
+import { createCanvasRenderer } from './index.js';
+import { TILE } from '../core/content.js';
+
+const { document } = new Window();
+// expose to renderer for document.createElement calls
+global.document = document;
+
+function makeCtx() {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = TILE * 2;
+  return canvas.getContext('2d');
+}
+
+function spyContext(ctx, methods) {
+  const calls = Object.fromEntries(methods.map(m => [m, 0]));
+  for (const m of methods) {
+    const orig = ctx[m].bind(ctx);
+    ctx[m] = (...args) => { calls[m]++; return orig(...args); };
+  }
+  return calls;
+}
+
+function baseState() {
+  return {
+    map: {
+      size: { cols: 2, rows: 2 },
+      blocked: [{ x: 0, y: 0 }],
+      buildableMask: [[false, true], [true, true]]
+    },
+    startPx: { x: 0, y: 0 },
+    endPx: { x: TILE, y: TILE },
+    path: null,
+    creeps: [], bullets: [], towers: [], particles: [], hover: null
+  };
+}
+
+// Grid drawing honouring showGrid option
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['stroke']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false } });
+  renderer.render(baseState());
+  assert.ok(calls.stroke > 0, 'grid strokes by default');
+})();
+
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['stroke']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showGrid: false } });
+  renderer.render(baseState());
+  assert.strictEqual(calls.stroke, 0, 'grid suppressed when showGrid=false');
+})();
+
+// Blocked tile overlay
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['strokeRect']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false } });
+  renderer.render(baseState());
+  assert.ok(calls.strokeRect > 0, 'blocked tiles drawn by default');
+})();
+
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['strokeRect']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false } });
+  renderer.render(baseState());
+  assert.strictEqual(calls.strokeRect, 0, 'blocked tiles suppressed when showBlocked=false');
+})();
+
+// Buildable mask overlay
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['fillRect']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false } });
+  renderer.render(baseState());
+  assert.ok(calls.fillRect > 0, 'build mask drawn by default');
+})();
+
+(() => {
+  const ctx = makeCtx();
+  const calls = spyContext(ctx, ['fillRect']);
+  const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false, showBuildMask: false } });
+  renderer.render(baseState());
+  assert.strictEqual(calls.fillRect, 0, 'build mask suppressed when showBuildMask=false');
+})();
+
+console.log('render-canvas tests passed');

--- a/packages/render-webgpu/index.test.js
+++ b/packages/render-webgpu/index.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert';
+import { createWebGPURenderer } from './index.js';
+
+async function unsupported() {
+  const oldNav = global.navigator;
+  global.navigator = {};
+  let threw = false;
+  try {
+    await createWebGPURenderer({ canvas: {}, engine: {} });
+  } catch (err) {
+    threw = true;
+  }
+  assert.ok(threw, 'throws when WebGPU unsupported');
+  global.navigator = oldNav;
+}
+
+async function supported() {
+  const beginCalls = [];
+  const submitCalls = [];
+
+  const pass = { end() {} };
+  const encoder = {
+    beginRenderPass(opts) { beginCalls.push(opts); return pass; },
+    finish() { return 'cmd'; }
+  };
+  const device = {
+    createCommandEncoder() { return encoder; },
+    queue: { submit(cmds) { submitCalls.push(cmds); } }
+  };
+  const adapter = { requestDevice: async () => device };
+  const gpu = {
+    requestAdapter: async () => adapter,
+    getPreferredCanvasFormat: () => 'rgba8unorm'
+  };
+  const context = {
+    configure() {},
+    getCurrentTexture: () => ({ createView: () => 'view' })
+  };
+  const canvas = { getContext: () => context };
+  const oldNav = global.navigator;
+  global.navigator = { gpu };
+  const renderer = await createWebGPURenderer({ canvas, engine: {} });
+  renderer.render({}, 0);
+  assert.strictEqual(beginCalls.length, 1, 'render pass begun');
+  const opts = beginCalls[0];
+  assert.strictEqual(opts.colorAttachments[0].loadOp, 'clear');
+  assert.deepStrictEqual(opts.colorAttachments[0].clearValue, { r: 0, g: 0, b: 0, a: 1 });
+  assert.strictEqual(submitCalls.length, 1, 'commands submitted');
+  global.navigator = oldNav;
+}
+
+await unsupported();
+await supported();
+
+console.log('render-webgpu tests passed');

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: 'happy-dom',
     coverage: {
-      provider: 'c8',
+      provider: 'v8',
       reporter: ['text', 'html'],
       thresholds: {
         lines: 100,


### PR DESCRIPTION
## Summary
- add unit tests for canvas renderer covering grid, blocked tiles, and build mask options
- add WebGPU renderer tests for unsupported environments and clear-pass behavior
- add `happy-dom` dev dependency for DOM mocking

## Testing
- `node packages/core/pathfinding.test.js`
- `node packages/render-canvas/index.test.js` *(fails: Cannot find package 'happy-dom')*
- `node packages/render-webgpu/index.test.js`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/happy-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68abe217ae60833088f1a91bf4099581