### PR TITLE
Expand combo tests and implement overload combo

### DIFF
--- a/packages/core/combat.js
+++ b/packages/core/combat.js
@@ -50,6 +50,7 @@ export function applyStatus(c, status, fromTower) {
     const hasShock = !!c.status[Status.SHOCK];
     const hasBrittle = !!c.status[Status.BRITTLE];
     const hasExposed = !!c.status[Status.EXPOSED];
+    const hasManaBurn = !!c.status[Status.MANA_BURN];
 
     if (hasBurn && hasPoison && !c.status.combo_acid) {
         c.status.combo_acid = 2.0;
@@ -71,6 +72,10 @@ export function applyStatus(c, status, fromTower) {
     if (hasExposed && hasBurn) {
         c.status[Status.BURN].dot *= 1.5;
         return 'combo.fanned';
+    }
+    if (hasManaBurn && hasShock) {
+        c.status.lightDot = { t: 1.5, dot: 12 };
+        return 'combo.overload';
     }
     return null;
 }

--- a/packages/core/combos.test.js
+++ b/packages/core/combos.test.js
@@ -9,4 +9,39 @@ describe('combos', () => {
     const result = applyStatus(creep, Status.POISON);
     expect(result).toBe('combo.acid');
   });
+
+  it('triggers shatter combo from chill and shock', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.CHILL);
+    const result = applyStatus(creep, Status.SHOCK);
+    expect(result).toBe('combo.shatter');
+  });
+
+  it('triggers neuroshock combo from poison and shock', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.POISON);
+    const result = applyStatus(creep, Status.SHOCK);
+    expect(result).toBe('combo.neuro');
+  });
+
+  it('triggers glassfire combo from brittle and burn', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.BRITTLE);
+    const result = applyStatus(creep, Status.BURN);
+    expect(result).toBe('combo.glassfire');
+  });
+
+  it('triggers fanned flames combo from exposed and burn', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.EXPOSED);
+    const result = applyStatus(creep, Status.BURN);
+    expect(result).toBe('combo.fanned');
+  });
+
+  it('triggers overload combo from mana burn and shock', () => {
+    const creep = { hp: 100, status: {}, resist: {} };
+    applyStatus(creep, Status.MANA_BURN);
+    const result = applyStatus(creep, Status.SHOCK);
+    expect(result).toBe('combo.overload');
+  });
 });


### PR DESCRIPTION
## Summary
- add tests for all status combos
- support `OVERLOAD` combo triggered by mana burn and shock

## Testing
- `npx vitest run packages/core/combos.test.js`
- `npm test` *(fails: packages/render-canvas/index.test.js: TypeError: Cannot read properties of null (reading 'stroke'); packages/render-webgpu/index.test.js: No test suite found; packages/core/creeps.test.js: Cannot read properties of undefined (reading 'push'); packages/core/progression.test.js: expected 1 to be greater than 1; packages/core/stats.test.js: expected undefined to be 1; packages/core/towers.test.js: expected 'a' to be 'b')*

------
https://chatgpt.com/codex/tasks/task_e_68abeee1f2148330bf5a06d61097befc