### PR TITLE
test: cover config merging

### DIFF
--- a/packages/core/config.js
+++ b/packages/core/config.js
@@ -2,15 +2,26 @@
 // configuration options for the engine library
 
 export const RENDER_BACKENDS = ['canvas', 'webgpu'];
+export const SOUND_BACKENDS = ['sfx', 'none'];
 
 export const defaultConfig = {
   renderer: 'webgpu',
+  sound: 'sfx',
+  speeds: { creep: 1, tower: 1 },
 };
 
 export function resolveConfig(user = {}) {
-  const cfg = { ...defaultConfig, ...user };
+  const cfg = {
+    ...defaultConfig,
+    ...user,
+    speeds: { ...defaultConfig.speeds, ...(user.speeds || {}) },
+  };
+
   if (!RENDER_BACKENDS.includes(cfg.renderer)) {
     cfg.renderer = defaultConfig.renderer;
+  }
+  if (!SOUND_BACKENDS.includes(cfg.sound)) {
+    cfg.sound = defaultConfig.sound;
   }
   return cfg;
 }

--- a/packages/core/config.test.js
+++ b/packages/core/config.test.js
@@ -1,9 +1,25 @@
 import { describe, it, expect } from 'vitest';
-import { resolveConfig } from './config.js';
+import { resolveConfig, defaultConfig } from './config.js';
 
 describe('config', () => {
   it('falls back to default renderer', () => {
     const cfg = resolveConfig({ renderer: 'invalid' });
     expect(cfg.renderer).toBe('webgpu');
+  });
+
+  it('merges partial user config preserving defaults', () => {
+    const cfg = resolveConfig({ speeds: { tower: 2 } });
+    expect(cfg.renderer).toBe(defaultConfig.renderer);
+    expect(cfg.sound).toBe(defaultConfig.sound);
+    expect(cfg.speeds.tower).toBe(2);
+    expect(cfg.speeds.creep).toBe(defaultConfig.speeds.creep);
+  });
+
+  it('keeps user options while falling back on invalid ones', () => {
+    const cfg = resolveConfig({ renderer: 'invalid', sound: 'invalid', speeds: { creep: 3 } });
+    expect(cfg.renderer).toBe(defaultConfig.renderer); // fallback
+    expect(cfg.sound).toBe(defaultConfig.sound); // fallback
+    expect(cfg.speeds.creep).toBe(3); // user option preserved
+    expect(cfg.speeds.tower).toBe(defaultConfig.speeds.tower); // default preserved
   });
 });


### PR DESCRIPTION
## Summary
- expand config defaults with sound and speed options
- ensure resolveConfig merges user options while validating renderer and sound
- test partial config merging and fallback behavior

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of null (reading 'stroke') and other suites)*
- `npx vitest run packages/core/config.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68abeee36e7483309a90d4b277b58f32