### PR TITLE
test: cover content constants and cannon alias

### DIFF
--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -71,6 +71,8 @@ export const REFUND_RATE = { basic: 0.8, elemental: 0.75 };
 export const COST = {
   ARCHER: 50,
   SIEGE: 65,
+  // Legacy alias for backwards compatibility
+  CANNON: 65,
   FIRE: 90,
   ICE: 90,
   LIGHT: 110,

--- a/packages/core/content.test.js
+++ b/packages/core/content.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { UPG_COST, COST, BLUEPRINT, ELEMENTS } from './content.js';
+
+describe('content', () => {
+  it('defines cost and blueprint for each element', () => {
+    for (const { key, type } of ELEMENTS) {
+      expect(COST[key]).toBeTypeOf('number');
+      const bp = BLUEPRINT[key];
+      expect(bp).toBeTruthy();
+      expect(bp.type).toBe(type);
+    }
+  });
+
+  it('basic vs elemental upgrade costs scale differently', () => {
+    const lvl = 2;
+    const basicCost = UPG_COST(lvl, 'ARCHER');
+    const elemCost = UPG_COST(lvl, 'FIRE');
+    expect(basicCost).toBe(40 + lvl * 30);
+    expect(elemCost).toBe(80 + lvl * 60);
+    expect(basicCost).toBeLessThan(elemCost);
+  });
+
+  it('falls back to legacy upgrade formula when elt omitted', () => {
+    expect(UPG_COST(3)).toBe(80 + 3 * 45);
+  });
+
+  it('legacy CANNON behaves like SIEGE', () => {
+    expect(COST.CANNON).toBe(COST.SIEGE);
+    expect(UPG_COST(1, 'CANNON')).toBe(UPG_COST(1, 'SIEGE'));
+    expect(BLUEPRINT.CANNON).toEqual(BLUEPRINT.SIEGE);
+  });
+
+  it('ELEMENTS list contains unique canonical keys', () => {
+    const keys = ELEMENTS.map(e => e.key);
+    expect(keys).toContain('ARCHER');
+    expect(keys).toContain('SIEGE');
+    expect(keys).not.toContain('CANNON');
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});


### PR DESCRIPTION
## Summary
- add missing CANNON cost entry so legacy references map to SIEGE
- add content tests covering upgrade cost scaling, element definitions, and alias behavior

## Testing
- `npx vitest run packages/core/content.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68abeee440788330aa02b7419d5a429d