### PR TITLE
fix tower targeting tie-break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/packages/core/towers.js
+++ b/packages/core/towers.js
@@ -47,23 +47,29 @@ export function targetInRange(state, t) {
 
     let best = null;
     if (mode === 'last') {
-        let bestProg = Infinity;
+        let bestProg = Infinity; let bestDist = Infinity;
         for (const c of candidates) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
-            if (dx * dx + dy * dy <= r2) {
+            const dist = dx * dx + dy * dy;
+            if (dist <= r2) {
                 const prog = c.seg + c.t;
-                if (prog < bestProg) { best = c; bestProg = prog; }
+                if (prog < bestProg || (prog === bestProg && dist < bestDist)) {
+                    best = c; bestProg = prog; bestDist = dist;
+                }
             }
         }
     } else {
-        let bestProg = -1;
+        let bestProg = -1; let bestDist = -1;
         for (const c of candidates) {
             if (!c.alive) continue;
             const dx = c.x - t.x, dy = c.y - t.y;
-            if (dx * dx + dy * dy <= r2) {
+            const dist = dx * dx + dy * dy;
+            if (dist <= r2) {
                 const prog = c.seg + c.t;
-                if (prog > bestProg) { best = c; bestProg = prog; }
+                if (prog > bestProg || (prog === bestProg && dist > bestDist)) {
+                    best = c; bestProg = prog; bestDist = dist;
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure towers choose farthest or nearest creep on progress ties
- ignore node_modules in git

## Testing
- `npx vitest run packages/core/towers.test.js`
- `npm test` *(fails: No test suite found in render-webgpu/index.test.js; cannot read properties of null in render-canvas/index.test.js; creeps/progression/stats tests also failing)*

------
https://chatgpt.com/codex/tasks/task_e_68abf38c45848330a9ba8e58f37d288c