### PR TITLE
fix stats summary kill access in test

### DIFF
--- a/packages/core/stats.test.js
+++ b/packages/core/stats.test.js
@@ -14,6 +14,7 @@ describe('stats', () => {
     // simulate a kill
     handlers.creepKill[0]({ type: 'Grunt', gold: 1 });
     const summary = stats.summary();
-    expect(summary.totals.creepsKilled).toBe(1);
+    // kills are reported inside totals.creeps
+    expect(summary.totals.creeps.killed).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- fix stats test to check creep kills in nested totals.creeps

## Testing
- `./node_modules/.bin/vitest run packages/core/stats.test.js --coverage=false`
- `npm test` *(fails: TypeError in render-canvas, no test suite for render-webgpu, undefined push in creeps, failing assertion in progression, targeting in towers)*

------
https://chatgpt.com/codex/tasks/task_e_68abf3a79ff4833089116260ece23f42