### PR TITLE
Refactor engine into modules and add integration tests

### DIFF
--- a/packages/core/engine.integration.test.js
+++ b/packages/core/engine.integration.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { createEngine, Elt } from './engine.js';
+import { COST, REFUND_RATE, UPG_COST, TILE } from './content.js';
+import { cellCenterForMap } from './map.js';
+
+const narrowMap = {
+  id: 'narrow',
+  name: 'narrow',
+  size: { cols: 3, rows: 3 },
+  start: { x: 0, y: 1 },
+  end: { x: 2, y: 1 },
+  blocked: [ { x: 1, y: 0 }, { x: 1, y: 2 } ],
+  buildableMask: null,
+  rules: {
+    allowElements: ['FIRE','POISON','ARCHER'],
+    maxWaves: 0,
+    autoWaveDefault: false,
+    speedCaps: [1,2,4],
+    disableEvolutions: false,
+    upgradeCredits: [2,4,6],
+  },
+  waves: {
+    mode: 'procedural',
+    authored: null,
+    scaling: { hp: 'linear(0.07)', speed: 'flat(0.005)', gold: 'interest(0.03)' }
+  }
+};
+
+function spawnTestCreep(engine) {
+  const base = engine.state.creepProfiles.Grunt;
+  const start = engine.state.map.start;
+  const end = engine.state.map.end;
+  const startPx = cellCenterForMap(engine.state.map, start.x, start.y);
+  const endPx = cellCenterForMap(engine.state.map, end.x, end.y);
+  const creep = {
+    id: 'c1',
+    type: 'Grunt',
+    x: startPx.x,
+    y: startPx.y,
+    seg: 0,
+    t: 0,
+    hp: base.hp,
+    maxhp: base.hp,
+    speed: base.speed,
+    resist: { ...base.resist },
+    gold: base.gold,
+    status: {},
+    alive: true,
+    path: [startPx, endPx]
+  };
+  engine.state.creeps.push(creep);
+  return creep;
+}
+
+describe('engine integration', () => {
+  it('enforces placement rules for path blocking and occupied tiles', () => {
+    const engine = createEngine({ map: narrowMap });
+    const res = engine.placeTower(1,1,Elt.ARCHER);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('blocks_path');
+
+    const creep = spawnTestCreep(engine);
+    creep.x = 0 * TILE + TILE/2;
+    creep.y = 0 * TILE + TILE/2;
+    const res2 = engine.placeTower(0,0,Elt.ARCHER);
+    expect(res2.ok).toBe(false);
+    expect(res2.reason).toBe('occupied_by_creep');
+  });
+
+  it('sells towers and refunds gold', () => {
+    const engine = createEngine({ map: narrowMap });
+    const goldStart = engine.state.gold;
+    const { tower } = engine.placeTower(0,0,Elt.ARCHER);
+    const goldAfterPlace = engine.state.gold;
+    engine.sellTower(tower.id);
+    const expected = goldStart - COST[Elt.ARCHER] + Math.floor(COST[Elt.ARCHER]*REFUND_RATE.basic);
+    expect(engine.state.gold).toBe(expected);
+    expect(engine.state.gold).toBeGreaterThan(goldAfterPlace);
+  });
+
+  it('levels up towers consuming gold', () => {
+    const engine = createEngine({ map: narrowMap });
+    engine.placeTower(0,0,Elt.ARCHER);
+    const tower = engine.selectTowerAt(0,0);
+    const cost = UPG_COST(tower.lvl, tower.elt);
+    const goldBefore = engine.state.gold;
+    const ok = engine.levelUpSelected();
+    expect(ok).toBe(true);
+    expect(tower.lvl).toBe(2);
+    expect(engine.state.gold).toBe(goldBefore - cost);
+  });
+
+  it('handles combo interactions and deterministic RNG', () => {
+    const engine1 = createEngine({ map: narrowMap, seed: 123 });
+    const engine2 = createEngine({ map: narrowMap, seed: 123 });
+    const r1 = engine1.state.rng.int(0,100);
+    const r2 = engine2.state.rng.int(0,100);
+    expect(r1).toBe(r2);
+
+    const comboEngine = createEngine({ map: narrowMap, seed: 555 });
+    comboEngine.placeTower(0,0,Elt.FIRE);
+    comboEngine.placeTower(0,2,Elt.POISON);
+    const creep = spawnTestCreep(comboEngine);
+    for (let i=0;i<200;i++) comboEngine.step(0.05);
+    expect(creep.status.combo_acid).toBeDefined();
+  });
+});

--- a/packages/core/engine/economy.js
+++ b/packages/core/engine/economy.js
@@ -1,0 +1,12 @@
+// packages/core/engine/economy.js
+
+export function changeGold(state, delta) {
+    state.gold += delta;
+    return state.gold;
+}
+
+export function changeLife(state, delta) {
+    state.lives += delta;
+    return state.lives;
+}
+

--- a/packages/core/engine/placement.js
+++ b/packages/core/engine/placement.js
@@ -1,0 +1,178 @@
+// packages/core/engine/placement.js
+
+import { Elt, BLUEPRINT, COST, TILE, BASIC_TOWERS, REFUND_RATE } from '../content.js';
+import { uuid } from '../rng.js';
+import { cellCenterForMap } from '../map.js';
+
+const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
+
+export const gridKey = (gx, gy) => `${gx},${gy}`;
+
+export function inBounds(state, gx, gy) {
+    return gx >= 0 && gy >= 0 && gx < state.map.size.cols && gy < state.map.size.rows;
+}
+
+export function isBlocked(state, towerGrid, canBuildCell, gx, gy) {
+    if (!inBounds(state, gx, gy)) return true;
+    const { start, end } = state.map;
+    if (gx === start.x && gy === start.y) return false;
+    if (gx === end.x && gy === end.y) return false;
+    if (!canBuildCell(gx, gy)) return true;
+    return towerGrid.has(gridKey(gx, gy));
+}
+
+export function gatherNeighbors(state, towerGrid, gx, gy) {
+    const range = 2;
+    const out = new Set();
+    for (let dx = -range; dx <= range; dx++) {
+        for (let dy = -range; dy <= range; dy++) {
+            if (dx === 0 && dy === 0) continue;
+            const n = towerGrid.get(gridKey(gx + dx, gy + dy));
+            if (n) out.add(n);
+        }
+    }
+    return out;
+}
+
+export function neighborsSynergy(state, towerGrid, targetTowers = state.towers) {
+    const r2 = (2 * TILE + 1) * (2 * TILE + 1);
+    const range = 2; // in tiles
+    for (const t of targetTowers) {
+        if (!t) continue;
+        const uniq = new Set();
+        for (let dx = -range; dx <= range; dx++) {
+            for (let dy = -range; dy <= range; dy++) {
+                if (dx === 0 && dy === 0) continue;
+                const n = towerGrid.get(gridKey(t.gx + dx, t.gy + dy));
+                if (!n) continue;
+                const px = n.x - t.x, py = n.y - t.y;
+                if (px * px + py * py <= r2) uniq.add(n.elt);
+            }
+        }
+        t.synergy = 0.08 * uniq.size;
+    }
+}
+
+export function canPlace(state, towerGrid, canBuildCell, gx, gy) {
+    if (!inBounds(state, gx, gy)) return false;
+    const { start, end } = state.map;
+    if (gx === start.x && gy === start.y) return false;
+    if (gx === end.x && gy === end.y) return false;
+    if (!canBuildCell(gx, gy)) return false;
+    if (towerGrid.has(gridKey(gx, gy))) return false;
+
+    const dist = state.pathGrid?.dist;
+    const px = cellCenterForMap(state.map, gx, gy);
+    const onPath = state.path?.some(p => p.x === px.x && p.y === px.y);
+    if (!dist || onPath) {
+        const { cols, rows } = state.map.size;
+        const visited = Array.from({ length: rows }, () => Array(cols).fill(false));
+        const q = [{ x: state.map.start.x, y: state.map.start.y }];
+        let head = 0;
+        visited[state.map.start.y][state.map.start.x] = true;
+        const dirs = [[1,0],[-1,0],[0,1],[0,-1]];
+        while (head < q.length) {
+            const cur = q[head++];
+            if (cur.x === state.map.end.x && cur.y === state.map.end.y) return true;
+            for (const [dx, dy] of dirs) {
+                const nx = cur.x + dx, ny = cur.y + dy;
+                if (nx < 0 || ny < 0 || nx >= cols || ny >= rows) continue;
+                if (visited[ny][nx]) continue;
+                if ((nx === gx && ny === gy) || isBlocked(state, towerGrid, canBuildCell, nx, ny)) continue;
+                if (dist && dist[ny][nx] === Infinity) continue;
+                visited[ny][nx] = true;
+                q.push({ x: nx, y: ny });
+            }
+        }
+        return false;
+    }
+    // tile not on cached path; existing path remains valid
+    return true;
+}
+
+const normalizeElt = (e) => (e === 'CANNON' ? Elt.SIEGE : e);
+
+export function placeTower(state, towerGrid, canBuildCell, gx, gy, rawElt, opts) {
+    const { onGoldChange, recomputePathingForAll, gatherNeighborsFn = gatherNeighbors, neighborsSynergyFn = neighborsSynergy, onTowerPlace } = opts;
+    const elt = normalizeElt(rawElt);
+    if (!inBounds(state, gx, gy)) return { ok: false, reason: 'oob' };
+    if (state.towers.some(t => t.gx === gx && t.gy === gy)) return { ok: false, reason: 'occupied' };
+    const { start, end } = state.map;
+    if (gx === start.x && gy === start.y) return { ok: false, reason: 'start' };
+    if (gx === end.x && gy === end.y) return { ok: false, reason: 'end' };
+    if (!canBuildCell(gx, gy)) return { ok: false, reason: 'not_buildable' };
+    if (!canPlace(state, towerGrid, canBuildCell, gx, gy)) return { ok: false, reason: 'blocks_path' };
+
+    for (const c of state.creeps) {
+        if (!c.alive) continue;
+        const cgx = Math.floor(c.x / TILE);
+        const cgy = Math.floor(c.y / TILE);
+        if (cgx === gx && cgy === gy) {
+            return { ok: false, reason: 'occupied_by_creep' };
+        }
+    }
+
+    const cost = COST[elt];
+    const bp = BLUEPRINT[elt];
+    if (cost == null || !bp) return { ok: false, reason: 'invalid_tower' };
+    if (state.gold < cost) return { ok: false, reason: 'gold' };
+
+    const t = {
+        id: uuid(), gx, gy,
+        x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2,
+        elt, lvl: 1, xp: 0, tree: [],
+        range: bp.range, firerate: bp.firerate, dmg: bp.dmg, type: bp.type, status: bp.status,
+        cooldown: 0, spent: cost,
+        mod: { dmg: 0, burn: 0, poison: 0, chill: 0, slowDur: 0, chainBounce: 0, chainRange: 0, stun: 0, aoe: 0, splash: 0,
+            nova: false, resShred: 0, maxStacks: 1, pierce: 0 },
+        synergy: 0, novaTimer: 0, kills: 0, freeTierPicks: 0,
+        targeting: 'first', _cycleIndex: 0,
+    };
+    state.towers.push(t);
+    towerGrid.set(gridKey(gx, gy), t);
+    onGoldChange(-cost, 'place_tower');
+    state.selectedTowerId = t.id;
+    const affected = gatherNeighborsFn(state, towerGrid, gx, gy);
+    affected.add(t);
+    neighborsSynergyFn(state, towerGrid, affected);
+    recomputePathingForAll(state, (x, y) => isBlocked(state, towerGrid, canBuildCell, x, y));
+    if (onTowerPlace) onTowerPlace(t, cost);
+    return { ok: true, tower: t };
+}
+
+export function sellTower(state, towerGrid, id, opts) {
+    const { onGoldChange, recomputePathingForAll, gatherNeighborsFn = gatherNeighbors, neighborsSynergyFn = neighborsSynergy, onTowerSell, canBuildCell } = opts;
+    const idx = state.towers.findIndex(t => t.id === id);
+    if (idx < 0) return false;
+    const t = state.towers[idx];
+    const isBasic = BASIC_TOWERS.includes(t.elt);
+    const rate = isBasic ? REFUND_RATE.basic : REFUND_RATE.elemental;
+    const refund = Math.floor(t.spent * rate);
+    state.towers.splice(idx, 1);
+    towerGrid.delete(gridKey(t.gx, t.gy));
+    if (state.selectedTowerId === id) state.selectedTowerId = null;
+
+    const affected = gatherNeighborsFn(state, towerGrid, t.gx, t.gy);
+    neighborsSynergyFn(state, towerGrid, affected);
+    recomputePathingForAll(state, (x, y) => isBlocked(state, towerGrid, canBuildCell, x, y));
+
+    onGoldChange(+refund, 'sell_tower');
+    if (onTowerSell) onTowerSell(t, refund);
+    return true;
+}
+
+export function setBuild(state, elt) {
+    state.buildSel = normalizeElt(elt);
+}
+
+export function setHover(state, gx, gy, canPlaceFn) {
+    state.hover.gx = gx; state.hover.gy = gy;
+    state.hover.valid = canPlaceFn(state, gx, gy);
+}
+
+export function selectTowerAt(state, gx, gy) {
+    const t = state.towers.find(tt => tt.gx === gx && tt.gy === gy);
+    state.selectedTowerId = t ? t.id : null;
+    return t || null;
+}
+

--- a/packages/core/engine/step.js
+++ b/packages/core/engine/step.js
@@ -1,0 +1,40 @@
+// packages/core/engine/step.js
+
+export function step(state, dt, deps) {
+    const { waves, advanceCreep, rebuildCreepGrid, fireTower, updateBullets, updateParticles, cullDead, onCreepLeak, onLifeChange, onCreepKill, onGoldChange, onShot, onHit, startWave } = deps;
+    if (state.paused || state.gameOver) return;
+    state.dt = dt;
+
+    waves.stepSpawner(dt);
+
+    for (const c of state.creeps) {
+        advanceCreep(state, c, () => {
+            onCreepLeak(c);
+            onLifeChange(-1, 'leak');
+        });
+        if (c.hp <= 0 && c.alive) { c.alive = false; }
+    }
+
+    rebuildCreepGrid(state);
+
+    for (const t of state.towers) { if (!t.ghost) fireTower(state, { onShot, onHit, onCreepDamage: deps.onCreepDamage }, t, dt); }
+
+    updateBullets(state, { onCreepDamage: deps.onCreepDamage });
+    updateParticles(state);
+
+    cullDead(state, {
+        onKill: (c) => { onCreepKill(c); onGoldChange(+c.gold, 'kill'); },
+    });
+
+    const canAuto = state.autoWaveEnabled && !state.gameOver && !waves.isSpawning() && state.creeps.length === 0;
+    if (canAuto) {
+        if (state._autoWaveTimer < 0) { state._autoWaveTimer = (state.autoWaveDelay || 0) / 1000; }
+        else {
+            state._autoWaveTimer -= dt;
+            if (state._autoWaveTimer <= 0) { state._autoWaveTimer = -1; startWave(); }
+        }
+    } else {
+        state._autoWaveTimer = -1;
+    }
+}
+

--- a/packages/core/engine/upgrades.js
+++ b/packages/core/engine/upgrades.js
@@ -1,0 +1,48 @@
+// packages/core/engine/upgrades.js
+
+import { UPG_COST, UNLOCK_TIERS, BASIC_TOWERS, UPGRADE_MULT, TREES } from '../content.js';
+
+export function levelUpSelected(state, deps) {
+    const { onGoldChange, neighborsSynergy, onTowerLevel } = deps;
+    const t = state.towers.find(tt => tt.id === state.selectedTowerId); if (!t) return false;
+    const cost = UPG_COST(t.lvl, t.elt); if (state.gold < cost) return false;
+
+    onGoldChange(-cost, 'level_up');
+    const prev = t.lvl;
+    t.lvl++;
+    t.spent += cost;
+    const mult = BASIC_TOWERS.includes(t.elt) ? UPGRADE_MULT.basic : UPGRADE_MULT.elemental;
+    t.dmg *= mult.dmg; t.firerate *= mult.firerate; t.range += mult.range;
+
+    const unlocked = UNLOCK_TIERS.filter(u => t.lvl >= u).length;
+    const credits = t.freeTierPicks || 0;
+    const owed = Math.max(0, unlocked - (t.tree.length + credits));
+    if (owed > 0) t.freeTierPicks = credits + owed;
+
+    neighborsSynergy(state);
+    if (onTowerLevel) onTowerLevel(t, prev, t.lvl, cost);
+    return true;
+}
+
+export function applyEvolution(state, key) {
+    const t = state.towers.find(tt => tt.id === state.selectedTowerId);
+    if (!t) return false;
+    if ((t.freeTierPicks || 0) <= 0) return false;
+    const branch = TREES[t.elt];
+    const currentTier = t.tree.length;
+    if (!branch || currentTier >= branch.length) return false;
+    const choices = branch[currentTier].filter(n => !n.req || t.tree.includes(n.req));
+    const chosen = choices.find(n => n.key === key); if (!chosen) return false;
+    chosen.mod(t); t.tree.push(chosen.key); t.freeTierPicks--;
+    return true;
+}
+
+export function setTargeting(state, mode) {
+    const t = state.towers.find(tt => tt.id === state.selectedTowerId);
+    if (!t) return false;
+    if (!['first', 'last', 'cycle'].includes(mode)) return false;
+    t.targeting = mode;
+    t._cycleIndex = 0;
+    return true;
+}
+


### PR DESCRIPTION
## Summary
- Split engine logic into placement, economy, upgrades, and step modules
- Rewired engine to use pure functions from new modules
- Added engine integration tests for placement, selling, upgrades, combos, and RNG determinism

## Testing
- `npm test` *(fails: render-canvas/index.test.js, render-webgpu/index.test.js, creeps.test.js, progression.test.js, stats.test.js, towers.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68abeee6238c8330833bf5d57bfed107