### PR TITLE
test: extend wave controller tests

### DIFF
--- a/packages/core/waves.test.js
+++ b/packages/core/waves.test.js
@@ -16,4 +16,73 @@ describe('waves', () => {
     for (let i = 0; i < 20; i++) ctrl.stepSpawner(1);
     expect(spawned).toBeGreaterThan(0);
   });
+
+  it('handles rewards and boss waves and ends when creeps die', () => {
+    const state = { wave: 0, creeps: [], gold: 0 };
+    const spawnedTypes = [];
+    const waveRewards = [];
+    const ctrl = createWaveController(state, {
+      getWavePacks: defaultWaveConfig,
+      spawnCreep: (type) => {
+        spawnedTypes.push(type);
+        state.creeps.push({});
+      },
+      onWaveStart: () => {},
+      onWaveEnd: (reward) => waveRewards.push(reward),
+      awardWaveGold: (amount) => {
+        state.gold += amount;
+      }
+    });
+
+    // --- wave 1 ---
+    expect(ctrl.startWave()).toBe(true);
+    while (spawnedTypes.length < 6) ctrl.stepSpawner(1);
+    // ensure not finished while creeps remain
+    ctrl.stepSpawner(1);
+    expect(waveRewards.length).toBe(0);
+    // all creeps die
+    state.creeps.length = 0;
+    ctrl.stepSpawner(1);
+    expect(waveRewards).toEqual([6]);
+
+    // --- wave 10 (boss) ---
+    state.wave = 9; // simulate advancing to wave 9
+    spawnedTypes.length = 0;
+    expect(ctrl.startWave()).toBe(true);
+    while (spawnedTypes.length < 1) ctrl.stepSpawner(1);
+    ctrl.stepSpawner(1); // grace step
+    expect(spawnedTypes).toEqual(['Boss']);
+    state.creeps.length = 0;
+    ctrl.stepSpawner(1);
+    expect(waveRewards).toEqual([6, 18]);
+    expect(state.gold).toBe(24);
+  });
+
+  it('tracks pack transitions and can reset spawner', () => {
+    const state = { wave: 1, creeps: [], gold: 0 };
+    const types = [];
+    const ctrl = createWaveController(state, {
+      getWavePacks: defaultWaveConfig,
+      spawnCreep: (type) => types.push(type),
+      onWaveStart: () => {},
+      onWaveEnd: () => {},
+      awardWaveGold: () => {}
+    });
+
+    expect(ctrl.startWave()).toBe(true); // wave 2 -> Grunts then Runners
+    for (let i = 0; i < 20; i++) ctrl.stepSpawner(1);
+    expect(types.slice(0, 8).every((t) => t === 'Grunt')).toBe(true);
+    expect(types.slice(8)).toEqual(Array(4).fill('Runner'));
+
+    ctrl.resetSpawner();
+    types.length = 0;
+    // step without starting again should spawn nothing
+    ctrl.stepSpawner(1);
+    expect(types.length).toBe(0);
+    // restart same wave number
+    state.wave = 1;
+    expect(ctrl.startWave()).toBe(true);
+    ctrl.stepSpawner(1);
+    expect(types[0]).toBe('Grunt');
+  });
 });


### PR DESCRIPTION
## Summary
- cover wave rewards and boss spawning
- verify pack transitions and reset behavior in wave controller

## Testing
- `npm test` *(fails: Coverage for lines (2.7%) does not meet global threshold (100%)...)*
- `npx vitest packages/core/waves.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68abeef303dc8330bf4ecb514184c144