### PR TITLE
Add tests for combos and elements modules

### DIFF
--- a/packages/core/combos.test.js
+++ b/packages/core/combos.test.js
@@ -1,12 +1,26 @@
 import { describe, it, expect } from 'vitest';
 import { applyStatus } from './combat.js';
 import { Status } from './content.js';
+import { combos } from './combos.js';
 
 describe('combos', () => {
+  it('defines the expected status interactions', () => {
+    expect(combos).toHaveLength(6);
+    expect(combos).toContainEqual({ when: ['BURN', 'POISON'], effect: 'ACID_BURN' });
+    expect(combos).toContainEqual({ when: ['CHILL', 'SHOCK'], effect: 'SHATTER' });
+  });
+
   it('triggers acid burn combo from burn and poison', () => {
     const creep = { hp: 100, status: {}, resist: {} };
     applyStatus(creep, Status.BURN);
     const result = applyStatus(creep, Status.POISON);
     expect(result).toBe('combo.acid');
+  });
+
+  it('triggers shatter combo from chill and shock', () => {
+    const creep = { hp: 200, status: {}, resist: {} };
+    applyStatus(creep, Status.CHILL);
+    const result = applyStatus(creep, Status.SHOCK);
+    expect(result).toBe('combo.shatter');
   });
 });

--- a/packages/core/elements.test.js
+++ b/packages/core/elements.test.js
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { elements } from './elements.js';
+import { Status } from './content.js';
+
+describe('elements', () => {
+  it('maps element keys to color and status', () => {
+    expect(elements.FIRE).toEqual({ color: '#ef4444', status: Status.BURN });
+    expect(elements.WIND).toEqual({ color: '#60a5fa', status: Status.EXPOSED });
+  });
+
+  it('omits status for basic towers', () => {
+    expect(elements.ARCHER).toEqual({ color: '#9ca3af', status: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for combos list and shatter combo behavior
- test element mappings for color and status

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfca550488330b78cca4ce9eb6661