### PR TITLE
feat(core): add image asset loader

### DIFF
--- a/packages/core/assets.js
+++ b/packages/core/assets.js
@@ -1,0 +1,43 @@
+// packages/core/assets.js
+// Basic image loader with caching and placeholder fallback
+
+const cache = new Map();
+
+// 1x1 transparent PNG
+const PLACEHOLDER_SRC =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII=';
+const placeholder = new Image();
+placeholder.src = PLACEHOLDER_SRC;
+
+function loadImage(src) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load ' + src));
+    img.src = src;
+  });
+}
+
+export async function loadImages(record) {
+  const entries = Object.entries(record);
+  const tasks = entries.map(async ([key, src]) => {
+    if (cache.has(key)) return cache.get(key);
+    try {
+      const img = await loadImage(src);
+      cache.set(key, img);
+    } catch {
+      cache.set(key, placeholder);
+    }
+    return cache.get(key);
+  });
+  await Promise.all(tasks);
+  const result = {};
+  for (const [key] of entries) {
+    result[key] = cache.get(key);
+  }
+  return result;
+}
+
+export function getImage(key) {
+  return cache.get(key) || placeholder;
+}

--- a/packages/core/assets.test.js
+++ b/packages/core/assets.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+function setupMockImage() {
+  const instances = [];
+  globalThis.Image = class {
+    constructor() {
+      instances.push(this);
+    }
+    set src(value) {
+      this._src = value;
+      setTimeout(() => {
+        if (value.includes('fail')) this.onerror?.(new Error('fail'));
+        else this.onload?.();
+      }, 0);
+    }
+    get src() { return this._src; }
+  };
+  return instances;
+}
+
+describe('assets loader', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('loads images and caches them', async () => {
+    setupMockImage();
+    const { loadImages, getImage } = await import('./assets.js');
+    const result = await loadImages({ hero: 'hero.png' });
+    const img = result.hero;
+    expect(img).toBeInstanceOf(Image);
+    expect(getImage('hero')).toBe(img);
+  });
+
+  it('falls back to placeholder on failure and missing keys', async () => {
+    setupMockImage();
+    const { loadImages, getImage } = await import('./assets.js');
+    const result = await loadImages({ bad: 'fail.png' });
+    const placeholder = getImage('missing');
+    expect(result.bad).toBe(placeholder);
+    expect(placeholder.src.startsWith('data:image/png;base64,')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add assets loader that caches images and falls back to a data URI placeholder sprite
- provide API to retrieve cached images
- cover loading, caching and fallback behaviors with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfd3a9c6083308baca228af0b1db7