### PR TITLE
Standardize sprite paths for towers and creeps

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,35 @@
+# Assets
+
+The engine resolves sprites through an asset manager. Each entity looks up an image using a
+key like `assetManager.getImage(key)` and stores the returned image on the instance.
+
+## Tower sprites
+
+Tower images live under a `towers/` directory and use the element id in lowercase. The engine
+will automatically look for a file matching the tower id:
+
+- `towers/archer.svg`
+- `towers/siege.svg`
+- `towers/fire.svg`
+- `towers/ice.svg`
+- `towers/light.svg`
+- `towers/poison.svg`
+- `towers/earth.svg`
+- `towers/wind.svg`
+- `towers/arcane.svg`
+
+## Creep sprites
+
+Creep images live under a `creeps/` directory and are named after the creep type:
+
+- `creeps/grunt.svg`
+- `creeps/runner.svg`
+- `creeps/tank.svg`
+- `creeps/shield.svg`
+- `creeps/boss.svg`
+
+All file names are lowercase. The engine supports both `.svg` and `.png`; SVG is recommended
+for clarity in this repo's sample assets. Custom assets should follow the same pattern so the
+engine can load them.
+
+Sample placeholder SVGs can be found under `docs/sample-assets/`.

--- a/docs/sample-assets/creeps/grunt.svg
+++ b/docs/sample-assets/creeps/grunt.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#4b5563"/>
+  <circle cx="16" cy="16" r="8" fill="#10b981"/>
+</svg>

--- a/docs/sample-assets/towers/archer.svg
+++ b/docs/sample-assets/towers/archer.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#9ca3af"/>
+  <circle cx="16" cy="16" r="10" fill="#ffffff"/>
+</svg>

--- a/packages/core/content.js
+++ b/packages/core/content.js
@@ -31,6 +31,7 @@ export const Status = {
 
 // Tower definitions used to derive helpers like EltColor, EltType and
 // EltStatus.  Non-elemental towers simply omit a status effect.
+const towerSprite = key => `towers/${key.toLowerCase()}.svg`;
 export const ELEMENTS = [
   { key: 'ARCHER', color: '#9ca3af', type: 'bolt' },
   { key: 'SIEGE', color: '#f59e0b', type: 'siege' },
@@ -41,11 +42,12 @@ export const ELEMENTS = [
   { key: 'EARTH', color: '#a3a3a3', type: 'splash', status: Status.BRITTLE },
   { key: 'WIND', color: '#60a5fa', type: 'bolt', status: Status.EXPOSED },
   { key: 'ARCANE', color: '#be123c', type: 'bolt', status: Status.MANA_BURN }
-];
+].map(e => ({ ...e, sprite: towerSprite(e.key) }));
 
 export const EltColor = Object.fromEntries(ELEMENTS.map(e => [e.key, e.color]));
 export const EltType = Object.fromEntries(ELEMENTS.map(e => [e.key, e.type]));
 export const EltStatus = Object.fromEntries(ELEMENTS.map(e => [e.key, e.status]));
+export const EltSprite = Object.fromEntries(ELEMENTS.map(e => [e.key, e.sprite]));
 
 // Non-elemental/basic towers that don't inflict statuses
 // Include legacy 'CANNON' for backwards compatibility, but the
@@ -133,6 +135,10 @@ export const ResistProfiles = {
   }
 };
 
+for (const [type, profile] of Object.entries(ResistProfiles)) {
+  profile.sprite = `creeps/${type.toLowerCase()}.svg`;
+}
+
 export const BLUEPRINT = {
   ARCHER: { range: 110, firerate: 1.1, dmg: 9, type: 'bolt', status: null },
   // Siege towers are the renamed cannon towers. They fire heavy shells
@@ -216,7 +222,7 @@ export const TREES = {
 
 export const defaultContent = {
   TILE, GRID_W, GRID_H, START, END,
-  Elt, Status, ELEMENTS, EltColor, EltType, EltStatus,
+  Elt, Status, ELEMENTS, EltColor, EltType, EltStatus, EltSprite,
   BASIC_TOWERS,
   COST, UPG_COST, UNLOCK_TIERS, ResistProfiles, BLUEPRINT, TREES,
   UPGRADE_MULT, REFUND_RATE,

--- a/packages/core/content.test.js
+++ b/packages/core/content.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { UPG_COST, COST, BLUEPRINT, ELEMENTS } from './content.js';
+import { UPG_COST, COST, BLUEPRINT, ELEMENTS, ResistProfiles } from './content.js';
 
 describe('content', () => {
   it('defines cost and blueprint for each element', () => {
@@ -36,5 +36,22 @@ describe('content', () => {
     expect(keys).toContain('SIEGE');
     expect(keys).not.toContain('CANNON');
     expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('defines a sprite path for each element', () => {
+    for (const { key, sprite } of ELEMENTS) {
+      expect(typeof sprite).toBe('string');
+      expect(sprite.startsWith('towers/')).toBe(true);
+      expect(sprite.endsWith('.svg')).toBe(true);
+    }
+  });
+
+  it('defines a sprite path for each creep profile', () => {
+    const types = ['Grunt', 'Runner', 'Tank', 'Shield', 'Boss'];
+    for (const type of types) {
+      const sprite = ResistProfiles[type].sprite;
+      expect(sprite.startsWith('creeps/')).toBe(true);
+      expect(sprite.endsWith('.svg')).toBe(true);
+    }
   });
 });

--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -23,6 +23,8 @@ export function createEngine(seedState, userConfig) {
     const engine = {};
     engine.config = resolveConfig(userConfig);
 
+    const assetManager = engine.config.assetManager;
+
     const state = createInitialState(seedState);
 
     // spatial index for towers keyed by grid coords "gx,gy"
@@ -51,6 +53,7 @@ export function createEngine(seedState, userConfig) {
             gatherNeighborsFn: gatherNeighbors,
             neighborsSynergyFn: neighborsSynergy,
             onTowerPlace,
+            assetManager,
         });
     }
 
@@ -172,6 +175,9 @@ export function createEngine(seedState, userConfig) {
         const startPx = cellCenterForMap(state.map, start.x, start.y);
         const endPx = cellCenterForMap(state.map, state.map.end.x, state.map.end.y);
 
+        const spriteKey = base.sprite;
+        const img = assetManager?.getImage ? assetManager.getImage(spriteKey) : undefined;
+
         const cr = {
             id: uuid(),
             type,
@@ -186,7 +192,8 @@ export function createEngine(seedState, userConfig) {
             alive: true,
             path: (state.path && state.path.length >= 2)
                 ? [...state.path]
-                : [startPx, endPx]
+                : [startPx, endPx],
+            img,
         };
 
         state.creeps.push(cr);

--- a/packages/core/engine/placement.js
+++ b/packages/core/engine/placement.js
@@ -1,6 +1,6 @@
 // packages/core/engine/placement.js
 
-import { Elt, BLUEPRINT, COST, TILE, BASIC_TOWERS, REFUND_RATE } from '../content.js';
+import { Elt, BLUEPRINT, COST, TILE, BASIC_TOWERS, REFUND_RATE, EltSprite } from '../content.js';
 import { uuid } from '../rng.js';
 import { cellCenterForMap } from '../map.js';
 
@@ -93,7 +93,7 @@ export function canPlace(state, towerGrid, canBuildCell, gx, gy) {
 const normalizeElt = (e) => (e === 'CANNON' ? Elt.SIEGE : e);
 
 export function placeTower(state, towerGrid, canBuildCell, gx, gy, rawElt, opts) {
-    const { onGoldChange, recomputePathingForAll, gatherNeighborsFn = gatherNeighbors, neighborsSynergyFn = neighborsSynergy, onTowerPlace } = opts;
+    const { onGoldChange, recomputePathingForAll, gatherNeighborsFn = gatherNeighbors, neighborsSynergyFn = neighborsSynergy, onTowerPlace, assetManager } = opts;
     const elt = normalizeElt(rawElt);
     if (!inBounds(state, gx, gy)) return { ok: false, reason: 'oob' };
     if (state.towers.some(t => t.gx === gx && t.gy === gy)) return { ok: false, reason: 'occupied' };
@@ -117,10 +117,14 @@ export function placeTower(state, towerGrid, canBuildCell, gx, gy, rawElt, opts)
     if (cost == null || !bp) return { ok: false, reason: 'invalid_tower' };
     if (state.gold < cost) return { ok: false, reason: 'gold' };
 
+    const spriteKey = EltSprite[elt];
+    const img = assetManager?.getImage ? assetManager.getImage(spriteKey) : undefined;
+
     const t = {
         id: uuid(), gx, gy,
         x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2,
         elt, lvl: 1, xp: 0, tree: [],
+        img,
         range: bp.range, firerate: bp.firerate, dmg: bp.dmg, type: bp.type, status: bp.status,
         cooldown: 0, spent: cost,
         mod: { dmg: 0, burn: 0, poison: 0, chill: 0, slowDur: 0, chainBounce: 0, chainRange: 0, stun: 0, aoe: 0, splash: 0,


### PR DESCRIPTION
## Summary
- derive tower and creep sprite paths from lowercase ids
- load svg sprites by convention and document asset folder layout
- add placeholder SVGs demonstrating expected structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfd3c22e88330a45e784e7c6d9de0