### PR TITLE
feat: support entity images and prep WebGPU textures

### DIFF
--- a/docs/SPRITES.md
+++ b/docs/SPRITES.md
@@ -1,0 +1,16 @@
+# Sprite naming convention
+
+The canvas renderer can automatically load images for creeps and towers when a
+`spritePath` (default `sprites/`) is available.  Image files are resolved by
+lower-casing the entity id and appending `.svg`.
+
+Examples:
+
+- a creep of type `Runner` → `sprites/runner.svg`
+- a tower of element `FIRE` → `sprites/fire.svg`
+
+If a matching file cannot be found, the renderer falls back to
+`creep.svg` or `tower.svg` in the same directory.
+
+Custom `img` properties on entities still take precedence and can point to any
+image.

--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -14,14 +14,12 @@ const { fit } = attachViewportFit(canvas, {
   headerSelector: 'header' // update to your actual header class/selector if you have one
 });
 const ctx = canvas.getContext('2d', { alpha: false });
-const renderer = createCanvasRenderer({
-  ctx,
-  engine,
-  sprites: {
-    creeps: { default: 'sprites/creep.svg' },
-    towers: { default: 'sprites/tower.svg' },
-  },
-});
+// The canvas renderer automatically loads sprites from the `sprites/` folder
+// using a naming convention based on creep type or tower element. For example,
+// a "Runner" creep will load `sprites/runner.svg` and an `ICE` tower will load
+// `sprites/ice.svg`. Missing files fall back to `sprites/creep.svg` or
+// `sprites/tower.svg`.
+const renderer = createCanvasRenderer({ ctx, engine });
 
 
 // ---------- Input helpers ----------

--- a/examples/vanilla/sprites/arcane.svg
+++ b/examples/vanilla/sprites/arcane.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 27,12 22,28 10,28 5,12" fill="#be123c" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/archer.svg
+++ b/examples/vanilla/sprites/archer.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 26,24 16,20 6,24" fill="#9ca3af" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/boss.svg
+++ b/examples/vanilla/sprites/boss.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 20,12 28,12 22,18 24,26 16,22 8,26 10,18 4,12 12,12" fill="#ef4444" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/earth.svg
+++ b/examples/vanilla/sprites/earth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 26,10 26,22 16,28 6,22 6,10" fill="#a3a3a3" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/fire.svg
+++ b/examples/vanilla/sprites/fire.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M16 4 L24 20 L8 20 Z" fill="#ef4444" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/grunt.svg
+++ b/examples/vanilla/sprites/grunt.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <circle cx="16" cy="16" r="14" fill="#9ca3af" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/ice.svg
+++ b/examples/vanilla/sprites/ice.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 28,16 16,28 4,16" fill="#38bdf8" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/light.svg
+++ b/examples/vanilla/sprites/light.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 19,12 28,12 21,18 24,26 16,21 8,26 11,18 4,12 13,12" fill="#a78bfa" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/poison.svg
+++ b/examples/vanilla/sprites/poison.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <circle cx="16" cy="16" r="12" fill="#22c55e" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/runner.svg
+++ b/examples/vanilla/sprites/runner.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 28,16 16,28 4,16" fill="#facc15" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/shield.svg
+++ b/examples/vanilla/sprites/shield.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <polygon points="16,4 28,10 28,22 16,28 4,22 4,10" fill="#60a5fa" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/siege.svg
+++ b/examples/vanilla/sprites/siege.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <rect x="4" y="8" width="24" height="16" fill="#f59e0b" stroke="#1f2937" stroke-width="2"/>
+  <circle cx="16" cy="16" r="4" fill="#1f2937"/>
+</svg>

--- a/examples/vanilla/sprites/tank.svg
+++ b/examples/vanilla/sprites/tank.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <rect x="4" y="4" width="24" height="24" fill="#a3a3a3" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/examples/vanilla/sprites/wind.svg
+++ b/examples/vanilla/sprites/wind.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">
+  <path d="M4 16 Q16 4 28 16 Q16 28 4 16 Z" fill="#60a5fa" stroke="#1f2937" stroke-width="2"/>
+</svg>

--- a/packages/render-canvas/index.test.js
+++ b/packages/render-canvas/index.test.js
@@ -7,6 +7,15 @@ import { TILE } from '../core/content.js';
 const { document } = new Window();
 // expose to renderer for document.createElement calls
 global.document = document;
+global.Image = class {
+  constructor() {
+    this.complete = true;
+    this.width = 16;
+    this.height = 16;
+  }
+  set src(v) { this._src = v; }
+  get src() { return this._src; }
+};
 
 function makeCtx() {
   const canvas = document.createElement('canvas');
@@ -74,7 +83,7 @@ describe('render-canvas', () => {
   it('suppresses blocked tiles when showBlocked=false', () => {
     const ctx = makeCtx();
     const calls = spyContext(ctx, ['strokeRect']);
-    const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false } });
+    const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false }, spritePath: null });
     renderer.render(baseState());
     assert.strictEqual(calls.strokeRect, 0, 'blocked tiles suppressed when showBlocked=false');
   });
@@ -93,6 +102,100 @@ describe('render-canvas', () => {
     const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false, showBuildMask: false } });
     renderer.render(baseState());
     assert.strictEqual(calls.fillRect, 0, 'build mask suppressed when showBuildMask=false');
+  });
+
+  it('draws creep sprite when img provided', () => {
+    const ctx = makeCtx();
+    let args;
+    ctx.drawImage = (...a) => { args = a; };
+    const img = { complete: true, width: 16, height: 16 };
+    const state = baseState();
+    state.creeps.push({ x: 16, y: 16, hp: 1, maxhp: 1, img, w: 20, h: 12 });
+    const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false, showBlocked: false } });
+    renderer.render(state);
+    assert.ok(args, 'drawImage called');
+    assert.strictEqual(args[1], -10, 'uses entity width');
+    assert.strictEqual(args[2], -6, 'uses entity height');
+    assert.strictEqual(args[3], 20, 'draws with provided width');
+    assert.strictEqual(args[4], 12, 'draws with provided height');
+  });
+
+  it('draws creep sprite by type using spritePath when no img provided', () => {
+    const ctx = makeCtx();
+    let used;
+    ctx.drawImage = (img) => { used = img.src; };
+    const state = baseState();
+    state.creeps.push({ x: 16, y: 16, hp: 1, maxhp: 1, type: 'Runner' });
+    const renderer = createCanvasRenderer({
+      ctx,
+      engine: {},
+      options: { cacheMap: false, showBlocked: false },
+      spritePath: 'img'
+    });
+    renderer.render(state);
+    assert.strictEqual(used, 'img/runner.svg', 'runner sprite inferred from type');
+  });
+
+  it('falls back to default creep sprite for unknown types', () => {
+    const ctx = makeCtx();
+    let used;
+    ctx.drawImage = (img) => { used = img.src; };
+    const state = baseState();
+    state.creeps.push({ x: 16, y: 16, hp: 1, maxhp: 1, type: 'Alien' });
+    const renderer = createCanvasRenderer({
+      ctx,
+      engine: {},
+      options: { cacheMap: false, showBlocked: false },
+      spritePath: 'img'
+    });
+    renderer.render(state);
+    assert.strictEqual(used, 'img/creep.svg', 'default creep sprite used');
+  });
+
+  it('falls back to tower shape when no img', () => {
+    const ctx = makeCtx();
+    let drew = false;
+    let drewImg = false;
+    ctx.arc = () => { drew = true; };
+    ctx.drawImage = () => { drewImg = true; };
+    const state = baseState();
+    state.towers.push({ id: 1, x: 16, y: 16, lvl: 1, range: 10, elt: 'FIRE' });
+    const renderer = createCanvasRenderer({ ctx, engine: {}, options: { cacheMap: false }, spritePath: null });
+    renderer.render(state);
+    assert.ok(drew, 'arc called for fallback tower shape');
+    assert.strictEqual(drewImg, false, 'drawImage not called');
+  });
+
+  it('uses tower sprite by element when no img provided', () => {
+    const ctx = makeCtx();
+    let used;
+    ctx.drawImage = (img) => { used = img.src; };
+    const state = baseState();
+    state.towers.push({ id: 1, x: 16, y: 16, lvl: 1, range: 10, elt: 'ICE' });
+    const renderer = createCanvasRenderer({
+      ctx,
+      engine: {},
+      options: { cacheMap: false },
+      spritePath: 'img'
+    });
+    renderer.render(state);
+    assert.strictEqual(used, 'img/ice.svg', 'ice tower sprite inferred from element');
+  });
+
+  it('falls back to default tower sprite for unknown elements', () => {
+    const ctx = makeCtx();
+    let used;
+    ctx.drawImage = (img) => { used = img.src; };
+    const state = baseState();
+    state.towers.push({ id: 1, x: 16, y: 16, lvl: 1, range: 10, elt: 'LASER' });
+    const renderer = createCanvasRenderer({
+      ctx,
+      engine: {},
+      options: { cacheMap: false },
+      spritePath: 'img'
+    });
+    renderer.render(state);
+    assert.strictEqual(used, 'img/tower.svg', 'default tower sprite used');
   });
 });
 

--- a/packages/render-webgpu/index.test.js
+++ b/packages/render-webgpu/index.test.js
@@ -50,6 +50,28 @@ describe('render-webgpu', () => {
     assert.strictEqual(submitCalls.length, 1, 'commands submitted');
     global.navigator = oldNav;
   });
+
+  it('creates textures for entity images (stub)', async () => {
+    let textureCalls = 0;
+    const pass = { end() {} };
+    const encoder = { beginRenderPass() { return pass; }, finish() { return 'cmd'; } };
+    const device = {
+      createCommandEncoder() { return encoder; },
+      createTexture() { textureCalls++; return {}; },
+      queue: { submit() {} }
+    };
+    const adapter = { requestDevice: async () => device };
+    const gpu = { requestAdapter: async () => adapter, getPreferredCanvasFormat: () => 'rgba8unorm' };
+    const context = { configure() {}, getCurrentTexture: () => ({ createView: () => 'view' }) };
+    const canvas = { getContext: () => context };
+    const oldNav = global.navigator;
+    global.navigator = { gpu };
+    const renderer = await createWebGPURenderer({ canvas, engine: {} });
+    const img = { complete: true, width: 1, height: 1 };
+    renderer.render({ creeps: [{ img }] }, 0);
+    assert.strictEqual(textureCalls, 1, 'texture created for sprite');
+    global.navigator = oldNav;
+  });
 });
 
 console.log('render-webgpu tests passed');


### PR DESCRIPTION
## Summary
- render creep and tower sprites when `img` provided, defaulting to entity-defined dimensions
- stub WebGPU texture caching for future sprite sampling
- test image sprite rendering, fallback paths, and per-type sprite mapping
- supply distinct SVG models for each tower and creep in the vanilla demo
- infer sprite file names from creep/tower ids with fallback defaults
- document sprite naming convention and update tests and demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abfd3d8b7083309a7282e838316bb9