### PR TITLE
Handle device pixel ratio for canvas fit

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -59,10 +59,26 @@ function toast(msg) {
 
 function sizeCanvasToCurrentMap() {
   const { cols, rows } = engine.state.map.size;
-  canvas.width = cols * TILE;
-  canvas.height = rows * TILE;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.width = cols * TILE * dpr;
+  canvas.height = rows * TILE * dpr;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   fit();
 }
+
+let dprMql;
+function watchDevicePixelRatio() {
+  if (dprMql) dprMql.removeEventListener('change', onDevicePixelRatioChange);
+  dprMql = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+  dprMql.addEventListener('change', onDevicePixelRatioChange);
+}
+
+function onDevicePixelRatioChange() {
+  sizeCanvasToCurrentMap();
+  watchDevicePixelRatio();
+}
+
+watchDevicePixelRatio();
 
 // Mouse
 canvas.addEventListener('contextmenu', e => e.preventDefault());

--- a/examples/vanilla/viewport-fit.js
+++ b/examples/vanilla/viewport-fit.js
@@ -29,8 +29,9 @@ export function attachViewportFit(canvas, {
     // main fit routine
     function fit() {
         // logical canvas size (set by app from map size)
-        const cw = canvas.width;
-        const ch = canvas.height;
+        const dpr = window.devicePixelRatio || 1;
+        const cw = canvas.width / dpr;
+        const ch = canvas.height / dpr;
         if (!cw || !ch) return;
 
         // available css box
@@ -68,6 +69,19 @@ export function attachViewportFit(canvas, {
         window.visualViewport.addEventListener('scroll', onResize);
     }
 
+    // refit when devicePixelRatio changes
+    let dprMql = null;
+    function watchDpr() {
+        if (dprMql) dprMql.removeEventListener('change', onDprChange);
+        dprMql = matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+        dprMql.addEventListener('change', onDprChange);
+    }
+    function onDprChange() {
+        fit();
+        watchDpr();
+    }
+    watchDpr();
+
     // refit when header / toolbar change size (responsive, dynamic content)
     const ro = 'ResizeObserver' in window ? new ResizeObserver(onResize) : null;
     if (ro) {
@@ -85,6 +99,7 @@ export function attachViewportFit(canvas, {
                 window.visualViewport.removeEventListener('resize', onResize);
                 window.visualViewport.removeEventListener('scroll', onResize);
             }
+            if (dprMql) dprMql.removeEventListener('change', onDprChange);
             if (ro) ro.disconnect();
             document.documentElement.style.overflowY = '';
             document.body.style.overflowY = '';


### PR DESCRIPTION
## Summary
- Scale canvas drawing buffer by `devicePixelRatio` and update 2D context transform
- Adjust viewport fitter to use logical dimensions and refit on pixel ratio changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad308259e083309b6e59e16cc810e6