### PR TITLE
feat: redesign mobile toolbar with play button and tower icons

### DIFF
--- a/examples/vanilla/app.js
+++ b/examples/vanilla/app.js
@@ -159,7 +159,12 @@ function refreshBuildPalette() {
     btn.classList.toggle('opacity-50', !affordable);
     btn.classList.toggle('pointer-events-none', !affordable);
     const label = elt[0] + elt.slice(1).toLowerCase();
-    btn.textContent = `${label} (${COST[elt]})`;
+    if (btn.dataset.icon) {
+      btn.title = `${label} (${COST[elt]})`;
+      btn.style.borderColor = EltColor[elt];
+    } else {
+      btn.textContent = `${label} (${COST[elt]})`;
+    }
   });
 }
 
@@ -172,6 +177,53 @@ function wirePaletteButtons(scope = document) {
   });
 }
 wirePaletteButtons(document);
+
+// Mobile tower details popup (long-press + slide)
+const towerBar = document.getElementById('towerBar');
+const towerPopup = document.getElementById('towerPopup');
+if (towerBar && towerPopup) {
+  let tpTimer = null;
+  let tpActive = false;
+  let tpCurrent = null;
+
+  const showPopup = (elt) => {
+    const label = elt[0] + elt.slice(1).toLowerCase();
+    towerPopup.textContent = `${label} (${COST[elt]})`;
+    towerPopup.style.opacity = '0';
+    towerPopup.classList.remove('hidden');
+    requestAnimationFrame(() => { towerPopup.style.opacity = '1'; });
+  };
+  const hidePopup = () => {
+    towerPopup.style.opacity = '0';
+    setTimeout(() => towerPopup.classList.add('hidden'), 200);
+  };
+  const cancel = () => {
+    if (tpTimer) clearTimeout(tpTimer);
+    if (tpActive) hidePopup();
+    tpTimer = null; tpActive = false; tpCurrent = null;
+  };
+
+  towerBar.addEventListener('pointerdown', (e) => {
+    const btn = e.target.closest('[data-elt]');
+    if (!btn) return;
+    tpCurrent = btn.dataset.elt;
+    tpTimer = setTimeout(() => { tpActive = true; showPopup(tpCurrent); }, 400);
+  });
+  towerBar.addEventListener('pointermove', (e) => {
+    if (!tpActive) return;
+    const el = document.elementFromPoint(e.clientX, e.clientY)?.closest('[data-elt]');
+    if (el && el.dataset.elt !== tpCurrent) {
+      tpCurrent = el.dataset.elt;
+      showPopup(tpCurrent);
+    }
+  });
+  towerBar.addEventListener('pointerup', () => {
+    if (tpActive && tpCurrent) { engine.setBuild(tpCurrent); refreshBuildPalette(); hidePopup(); }
+    cancel();
+  });
+  towerBar.addEventListener('pointerleave', cancel);
+  towerBar.addEventListener('pointercancel', cancel);
+}
 
 // Hotkeys
 window.addEventListener('keydown', (e) => {
@@ -201,6 +253,20 @@ const binds = {
 
 let waveTime = 0;
 let waveRunning = false;
+const mPlay = document.getElementById('mPlay');
+
+function updatePlayButton() {
+  if (!mPlay) return;
+  mPlay.textContent = '▶';
+  mPlay.classList.remove('bg-green-600', 'bg-yellow-600', 'bg-slate-800');
+  if (engine.state.autoWaveEnabled) {
+    mPlay.classList.add('bg-green-600');
+  } else if (waveRunning) {
+    mPlay.classList.add('bg-yellow-600');
+  } else {
+    mPlay.classList.add('bg-slate-800');
+  }
+}
 
 function syncHud() {
   const h = buildHudSnapshot(engine.state);
@@ -210,6 +276,7 @@ function syncHud() {
   binds.waveTimer.forEach(el => el.textContent = '');
   refreshBuildPalette();
   repaintTowerDetails(false);
+  updatePlayButton();
 }
 
 async function repaintTowerDetails(force = true) {
@@ -287,9 +354,16 @@ const updateSpeedLabel = () => { if (fastBtn) fastBtn.textContent = (engine.stat
 fastBtn && (fastBtn.onclick = () => { engine.cycleSpeed(); updateSpeedLabel(); });
 updateSpeedLabel();
 
-document.getElementById('mStart')?.addEventListener('click', () => engine.startWave());
-document.getElementById('mPause')?.addEventListener('click', () => engine.setPaused(!engine.state.paused));
-document.getElementById('mFast')?.addEventListener('click', () => engine.cycleSpeed());
+mPlay?.addEventListener('click', () => {
+  if (engine.state.autoWaveEnabled) {
+    engine.setAutoWave(false, engine.state.autoWaveDelay);
+  } else if (waveRunning) {
+    engine.setAutoWave(true, engine.state.autoWaveDelay);
+  } else {
+    engine.startWave();
+  }
+  updatePlayButton();
+});
 
 const goModal = document.getElementById('goModal');
 const goBody = document.getElementById('goBody');
@@ -307,8 +381,8 @@ document.getElementById('goRestart')?.addEventListener('click', () => {
 // ---------- Event-driven UI refresh ----------
 engine.hook('goldChange', () => syncHud());
 engine.hook('creepKill', () => syncHud());
-engine.hook('waveStart', () => { waveTime = 0; waveRunning = true; });
-engine.hook('waveEnd', () => { waveRunning = false; waveTime = 0; syncHud(); });
+engine.hook('waveStart', () => { waveTime = 0; waveRunning = true; updatePlayButton(); });
+engine.hook('waveEnd', () => { waveRunning = false; waveTime = 0; syncHud(); updatePlayButton(); });
 engine.hook('lifeChange', () => syncHud());
 
 engine.hook('mapChange', ({ size }) => {
@@ -332,8 +406,6 @@ engine.hook('speedChange', ({ speed }) => {
   const label = (speed === 1 ? '1×' : speed === 2 ? '2×' : '4×');
   const fastElem = document.getElementById('fast');
   if (fastElem) fastElem.textContent = label;
-  const mFastElem = document.getElementById('mFast');
-  if (mFastElem) mFastElem.textContent = label;
 });
 
 engine.hook('gameOver', (ev) => {
@@ -394,6 +466,7 @@ engine.hook('autoWaveChange', ({ enabled, delay }) => {
   if (awToggle) awToggle.checked = !!enabled;
   if (awHUD) awHUD.checked = !!enabled;
   if (awDelay && typeof delay === 'number') awDelay.value = String(delay);
+  updatePlayButton();
 });
 
 if (awToggle) awToggle.checked = engine.state.autoWaveEnabled;

--- a/examples/vanilla/index.html
+++ b/examples/vanilla/index.html
@@ -10,7 +10,7 @@
     href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='28' fill='%238b5cf6'/%3E%3Ccircle cx='24' cy='28' r='6' fill='%23ef4444'/%3E%3Ccircle cx='42' cy='38' r='6' fill='%2338bdf8'/%3E%3C/svg%3E" />
   <style>
     :root {
-      --toolbar-h: 88px;
+      --toolbar-h: 128px;
     }
 
     body {
@@ -92,29 +92,48 @@
     </aside>
   </div>
 
-  <!-- Mobile bottom toolbar (single source of truth on mobile) -->
+  <!-- Mobile bottom toolbar (play button + tower bar) -->
   <div
     class="mobile-toolbar fixed md:hidden inset-x-0 bottom-0 pb-[env(safe-area-inset-bottom)] bg-[rgba(5,8,16,.9)] border-t border-slate-700/60 backdrop-blur"
     id="mToolbar" style="height:var(--toolbar-h)">
-    <div class="max-w-[1200px] mx-auto h-full px-3 flex items-center justify-between gap-2">
-      <div class="flex gap-2">
-        <button id="mStart" class="px-3 py-2 border rounded text-sm">Start</button>
-        <button id="mPause" class="px-3 py-2 border rounded text-sm">Pause</button>
-        <button id="mFast" class="px-3 py-2 border rounded text-sm">FF</button>
+    <div class="max-w-[1200px] mx-auto h-full px-3 flex flex-col justify-center gap-2 relative">
+      <div class="flex items-center justify-between">
+        <button id="mPlay" class="w-12 h-12 rounded-full border border-slate-600 flex items-center justify-center text-xl bg-slate-800">
+          ▶
+        </button>
+        <div class="text-xs opacity-80">Gold <span data-bind="gold">-</span> • Lives <span data-bind="lives">-</span> •
+          Wave <span data-bind="wave">-</span><span data-bind="waveTimer" class="ml-1"></span></div>
       </div>
-      <div class="text-xs opacity-80">Gold <span data-bind="gold">-</span> • Lives <span data-bind="lives">-</span> •
-        Wave <span data-bind="wave">-</span><span data-bind="waveTimer" class="ml-1"></span></div>
-      <div class="grid grid-cols-3 gap-2 ml-2">
-        <button data-elt="ARCHER" class="px-3 py-2 border rounded text-xs">Archer</button>
-        <button data-elt="SIEGE" class="px-3 py-2 border rounded text-xs">Siege</button>
-        <button data-elt="FIRE" class="px-3 py-2 border rounded text-xs">Fire</button>
-        <button data-elt="ICE" class="px-3 py-2 border rounded text-xs">Ice</button>
-        <button data-elt="LIGHT" class="px-3 py-2 border rounded text-xs">Lightning</button>
-        <button data-elt="POISON" class="px-3 py-2 border rounded text-xs">Poison</button>
-        <button data-elt="EARTH" class="px-3 py-2 border rounded text-xs">Earth</button>
-        <button data-elt="WIND" class="px-3 py-2 border rounded text-xs">Wind</button>
-        <button data-elt="ARCANE" class="px-3 py-2 border rounded text-xs">Arcane</button>
+      <div id="towerBar" class="flex gap-2 overflow-x-auto">
+        <button data-elt="ARCHER" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/archer.svg" alt="Archer" class="w-8 h-8" />
+        </button>
+        <button data-elt="SIEGE" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/siege.svg" alt="Siege" class="w-8 h-8" />
+        </button>
+        <button data-elt="FIRE" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/fire.svg" alt="Fire" class="w-8 h-8" />
+        </button>
+        <button data-elt="ICE" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/ice.svg" alt="Ice" class="w-8 h-8" />
+        </button>
+        <button data-elt="LIGHT" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/light.svg" alt="Lightning" class="w-8 h-8" />
+        </button>
+        <button data-elt="POISON" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/poison.svg" alt="Poison" class="w-8 h-8" />
+        </button>
+        <button data-elt="EARTH" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/earth.svg" alt="Earth" class="w-8 h-8" />
+        </button>
+        <button data-elt="WIND" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/wind.svg" alt="Wind" class="w-8 h-8" />
+        </button>
+        <button data-elt="ARCANE" data-icon class="w-10 h-10 border rounded flex items-center justify-center flex-none">
+          <img src="sprites/arcane.svg" alt="Arcane" class="w-8 h-8" />
+        </button>
       </div>
+      <div id="towerPopup" class="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden px-3 py-2 rounded bg-slate-900 border border-slate-700 text-xs opacity-0 transition-opacity"></div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- add bottom play button that toggles autowave and updates while waves run
- show tower selection as colored icon bar with long‑press info popup
- support mobile tower palette with icon styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad3cd8aa948330be3534f8d5c9ee8b