### PR TITLE
Use deterministic IDs from seeded RNG

### DIFF
--- a/packages/core/engine.js
+++ b/packages/core/engine.js
@@ -7,7 +7,6 @@ import { recomputePathingForAll, advanceCreep, cullDead } from './creeps.js';
 import { fireTower } from './towers.js';
 import { updateBullets } from './bullets.js';
 import { updateParticles, clearParticlePool } from './particles.js';
-import { uuid } from './rng.js';
 import { validateMap, makeBuildableChecker, cellCenterForMap } from './map.js';
 import { attachStats } from './stats.js';
 import { rebuildCreepGrid } from './spatial.js';
@@ -231,7 +230,7 @@ export function createEngine(seedState, userConfig) {
         const endPx = cellCenterForMap(state.map, state.map.end.x, state.map.end.y);
 
         const cr = {
-            id: uuid(),
+            id: state.idGen(),
             type,
             x: startPx.x, y: startPx.y,
             z: base.z ?? 0,

--- a/packages/core/engine/placement.js
+++ b/packages/core/engine/placement.js
@@ -1,7 +1,6 @@
 // packages/core/engine/placement.js
 
 import { Elt, BLUEPRINT, COST, TILE, BASIC_TOWERS, REFUND_RATE } from '../content.js';
-import { uuid } from '../rng.js';
 import { cellCenterForMap } from '../map.js';
 
 const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
@@ -118,7 +117,7 @@ export function placeTower(state, towerGrid, canBuildCell, gx, gy, rawElt, opts)
     if (state.gold < cost) return { ok: false, reason: 'gold' };
 
     const t = {
-        id: uuid(), gx, gy,
+        id: state.idGen(), gx, gy,
         x: gx * TILE + TILE / 2, y: gy * TILE + TILE / 2,
         z: bp.z ?? 0,
         baseZ: bp.z ?? 0,

--- a/packages/core/rng.js
+++ b/packages/core/rng.js
@@ -1,5 +1,5 @@
 // packages/core/rng.js
-// Deterministic mulberry32 RNG + UUID fallback
+// Deterministic mulberry32 RNG + deterministic id generator
 export function mulberry32(seed) {
     let t = seed >>> 0;
     return function () {
@@ -19,12 +19,26 @@ export function makeRng(seed) {
     return rnd;
 }
 
-export function uuid() {
-    const g = (typeof globalThis !== 'undefined' ? globalThis : window);
-    if (g.crypto && typeof g.crypto.randomUUID === 'function') return g.crypto.randomUUID();
-    // RFC4122-ish v4 polyfill
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
-        const r = (Math.random() * 16) | 0, v = c === 'x' ? r : ((r & 0x3) | 0x8);
-        return v.toString(16);
-    });
+export function makeIdGenerator(seed) {
+    // Keep deterministic output even without an explicit seed.
+    const baseSeed = (typeof seed === 'number') ? seed : 0xABCDEF;
+    const rnd = mulberry32((baseSeed ^ 0x9E3779B9) >>> 0);
+    let counter = 0;
+    const hex = (n, len) => n.toString(16).padStart(len, '0');
+
+    return function uuid() {
+        const a = (rnd() * 0xFFFFFFFF) >>> 0;
+        const b = (rnd() * 0xFFFFFFFF) >>> 0;
+        const c = (rnd() * 0xFFFFFFFF) >>> 0;
+        const d = (rnd() * 0xFFFFFFFF) >>> 0;
+        counter = (counter + 1) >>> 0;
+
+        const p1 = hex(a, 8);
+        const p2 = hex(b >>> 16, 4);
+        const p3 = hex((b & 0xFFFF) | 0x4000, 4); // set version bits
+        const p4 = hex(((c >>> 16) & 0x3FFF) | 0x8000, 4); // set variant bits
+        const p5 = hex(((c & 0xFFFF) << 16) | (d >>> 16), 8) + hex((d & 0xFFFF) ^ counter, 4);
+
+        return `${p1}-${p2}-${p3}-${p4}-${p5}`;
+    };
 }

--- a/packages/core/state.js
+++ b/packages/core/state.js
@@ -2,15 +2,17 @@
 // State now carries a "map" (validated by engine.loadMap)
 
 import { createDefaultMap, cellCenterForMap } from './map.js';
-import { makeRng } from './rng.js';
+import { makeIdGenerator, makeRng } from './rng.js';
 import { Elt, ResistProfiles } from './content.js';
 
 export function createInitialState(seedState) {
     const rng = makeRng(seedState?.seed ?? undefined);
+    const idGen = makeIdGenerator(rng.seed);
     const map = seedState?.map ?? createDefaultMap();
     return {
         rng,
         seed: rng.seed,
+        idGen,
         map,
 
         gold: 250,
@@ -62,6 +64,7 @@ export function createInitialState(seedState) {
 export function resetState(state, keep = {}) {
     const seed = keep.seed ?? state.seed;
     const rng = state.rng;
+    state.idGen = makeIdGenerator(seed);
 
     Object.assign(state, {
         rng, seed,


### PR DESCRIPTION
## Summary
- add a deterministic id generator built from the seeded RNG
- thread the generator into state so creeps and towers reuse it
- update creep and tower creation to use the deterministic ids

## Testing
- npm test --silent


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f77e8c4548330ae61c9bd9e95c9c1)